### PR TITLE
add support for arc-swap

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,15 +4,22 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v1
     - name: Build
       run: cargo build --verbose
     - name: Test
       run: cargo test
+
+  build-all:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build
+      run: cargo build --verbose --all-features
+    - name: Test
+      run: cargo test --all-features
 
   miri:
     runs-on: ubuntu-latest
@@ -22,3 +29,5 @@ jobs:
       run: rustup toolchain install nightly --component miri --profile minimal
     - name: Miri Test
       run: cargo +nightly miri test
+    - name: Miri Test all features
+      run: cargo +nightly miri test --all-features

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/Cargo.lock
 /target
 **/*.rs.bk

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "triomphe"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["The Servo Project Developers"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/Manishearth/triomphe"
@@ -12,8 +12,8 @@ categories = ["concurrency", "data-structures"]
 name = "triomphe"
 path = "lib.rs"
 
-
 [dependencies]
+arc-swap = { version = ">= 0.2, < 0.5", optional = true }
 memoffset = "0.5.3"
 serde = "1.0"
-stable_deref_trait = "1.0.0"
+stable_deref_trait = "1.0"


### PR DESCRIPTION
I tried to use `triomphe` with `arc-swap`, but noticed that the `from_raw`/`into_raw` methods are private. They aren't needed directly, but needed to sanely implement the `arc-swap::RefCnt` trait. In this PR, I simply implemented the `RefCnt` trait itself (and added some basic smoke tests).