### PR TITLE
Expose direct access to length

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -125,7 +125,7 @@ pub struct HeaderWithLength<H> {
     pub header: H,
 
     /// The slice length.
-    pub(crate) length: usize,
+    pub length: usize,
 }
 
 impl<H> HeaderWithLength<H> {


### PR DESCRIPTION
Note that HeaderWithLength::new function is public, so we already can
muck with the length field:

    use triomphe::{HeaderWithLength, ThinArc, Arc};

    fn main() {
        let thin_arc = ThinArc::from_header_and_iter((), std::iter::once(92));
        let mut arc = Arc::from_thin(thin_arc);
        Arc::get_mut(&mut arc).unwrap().header = HeaderWithLength::new((), 2);
        let thin_arc = Arc::into_thin(arc);
        eprintln!("{:?}", &thin_arc.slice);
    }

This is not UB because there are necessary runtime assertions to make
sure that the length is correct.

Having access to the length field would allow clients to do thin->thick
transforms themselves, which might be used to, eg, extrac a thin
reference out of ThinArc