### PR TITLE
Implement unsize crate's trait CoerciblePtr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,4 +34,14 @@ dependencies = [
  "memoffset",
  "serde",
  "stable_deref_trait",
+ "unsize",
+]
+
+[[package]]
+name = "unsize"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fa7a7a734c1a5664a662ddcea0b6c9472a21da8888c957c7f1eaa09dba7a939"
+dependencies = [
+ "autocfg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ default = ["serde", "stable_deref_trait", "std"]
 memoffset = "0.6"
 serde = { version = "1.0", default-features = false, optional = true }
 stable_deref_trait = { version = "1.1.1", default-features = false, optional = true }
-unsize = "1.1"
+unsize = { version = "1.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ default = ["serde", "stable_deref_trait", "std"]
 memoffset = "0.6"
 serde = { version = "1.0", default-features = false, optional = true }
 stable_deref_trait = { version = "1.1.1", default-features = false, optional = true }
+unsize = "1.1"

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -454,6 +454,7 @@ impl<T: Serialize> Serialize for Arc<T> {
 // any unsized ArcInner valid for being shared with the sized variant.
 // This does _not_ mean that any T can be unsized into an U, but rather than if such unsizing is
 // possible then it can be propagated into the Arc<T>.
+#[cfg(feature = "unsize")]
 unsafe impl<T, U: ?Sized> unsize::CoerciblePtr<U> for Arc<T> {
     type Pointee = T;
     type Output = Arc<U>;
@@ -480,6 +481,7 @@ unsafe impl<T, U: ?Sized> unsize::CoerciblePtr<U> for Arc<T> {
 }
 
 #[cfg(test)]
+#[cfg(feature = "unsize")]
 mod tests {
     use crate::arc::Arc;
     use unsize::{Coercion, CoerceUnsize};

--- a/src/arc_borrow.rs
+++ b/src/arc_borrow.rs
@@ -21,7 +21,7 @@ use super::Arc;
 /// without needing to worry about where the `Arc<T>` is.
 #[derive(Debug, Eq, PartialEq)]
 #[repr(transparent)]
-pub struct ArcBorrow<'a, T: 'a>(pub(crate) &'a T);
+pub struct ArcBorrow<'a, T: ?Sized + 'a>(pub(crate) &'a T);
 
 impl<'a, T> Copy for ArcBorrow<'a, T> {}
 impl<'a, T> Clone for ArcBorrow<'a, T> {
@@ -43,6 +43,8 @@ impl<'a, T> ArcBorrow<'a, T> {
 
     /// For constructing from a reference known to be Arc-backed,
     /// e.g. if we obtain such a reference over FFI
+    /// TODO: should from_ref be relaxed to unsized types? It can't be
+    /// converted back to an Arc right now for unsized types.
     #[inline]
     pub unsafe fn from_ref(r: &'a T) -> Self {
         ArcBorrow(r)
@@ -87,5 +89,20 @@ impl<'a, T> Deref for ArcBorrow<'a, T> {
     #[inline]
     fn deref(&self) -> &T {
         self.0
+    }
+}
+
+unsafe impl<'lt, T: 'lt, U: ?Sized + 'lt> unsize::CoerciblePtr<U> for ArcBorrow<'lt, T> {
+    type Pointee = T;
+    type Output = ArcBorrow<'lt, U>;
+    fn as_sized_ptr(&mut self) -> *mut T {
+        // Returns a pointer to the inner data. We do not need to care about any particular
+        // provenance here, only the pointer value, which we need to reconstruct the new pointer.
+        self.0 as *const T as *mut T
+    }
+    unsafe fn replace_ptr(self, new: *mut U) -> ArcBorrow<'lt, U> {
+        let inner = ManuallyDrop::new(self);
+        // Safety: backed by the same Arc that backed `self`.
+        ArcBorrow(inner.0.replace_ptr(new))
     }
 }

--- a/src/arc_borrow.rs
+++ b/src/arc_borrow.rs
@@ -98,6 +98,7 @@ impl<'a, T> Deref for ArcBorrow<'a, T> {
 // continues to point to the data of an ArcInner. The reference count remains untouched which is
 // correct since the number of owners did not change. This implies the returned instance fulfills
 // its safety invariants.
+#[cfg(feature = "unsize")]
 unsafe impl<'lt, T: 'lt, U: ?Sized + 'lt> unsize::CoerciblePtr<U> for ArcBorrow<'lt, T> {
     type Pointee = T;
     type Output = ArcBorrow<'lt, U>;

--- a/src/arc_borrow.rs
+++ b/src/arc_borrow.rs
@@ -92,14 +92,22 @@ impl<'a, T> Deref for ArcBorrow<'a, T> {
     }
 }
 
+// Safety:
+// This implementation must guarantee that it is sound to call replace_ptr with an unsized variant
+// of the pointer retuned in `as_sized_ptr`. We leverage unsizing the contained reference. This
+// continues to point to the data of an ArcInner. The reference count remains untouched which is
+// correct since the number of owners did not change. This implies the returned instance fulfills
+// its safety invariants.
 unsafe impl<'lt, T: 'lt, U: ?Sized + 'lt> unsize::CoerciblePtr<U> for ArcBorrow<'lt, T> {
     type Pointee = T;
     type Output = ArcBorrow<'lt, U>;
+
     fn as_sized_ptr(&mut self) -> *mut T {
         // Returns a pointer to the inner data. We do not need to care about any particular
         // provenance here, only the pointer value, which we need to reconstruct the new pointer.
         self.0 as *const T as *mut T
     }
+
     unsafe fn replace_ptr(self, new: *mut U) -> ArcBorrow<'lt, U> {
         let inner = ManuallyDrop::new(self);
         // Safety: backed by the same Arc that backed `self`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,19 +31,20 @@ extern crate memoffset;
 extern crate serde;
 #[cfg(feature = "stable_deref_trait")]
 extern crate stable_deref_trait;
+extern crate unsize;
 
 mod arc;
-mod header;
-mod arc_union;
 mod arc_borrow;
+mod arc_union;
+mod header;
 mod offset_arc;
 mod thin_arc;
 mod unique_arc;
 
 pub use arc::*;
-pub use header::*;
-pub use arc_union::*;
 pub use arc_borrow::*;
+pub use arc_union::*;
+pub use header::*;
 pub use offset_arc::*;
 pub use thin_arc::*;
 pub use unique_arc::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ extern crate memoffset;
 extern crate serde;
 #[cfg(feature = "stable_deref_trait")]
 extern crate stable_deref_trait;
+#[cfg(feature = "unsize")]
 extern crate unsize;
 
 mod arc;

--- a/src/offset_arc.rs
+++ b/src/offset_arc.rs
@@ -9,7 +9,7 @@ use super::{Arc, ArcBorrow};
 /// An `Arc`, except it holds a pointer to the T instead of to the
 /// entire ArcInner.
 ///
-/// An `OffsetArc<T>` has the same layout and ABI as a non-null 
+/// An `OffsetArc<T>` has the same layout and ABI as a non-null
 /// `const T*` in C, and may be used in FFI function signatures.
 ///
 /// ```text

--- a/src/unique_arc.rs
+++ b/src/unique_arc.rs
@@ -98,13 +98,20 @@ impl<T> DerefMut for UniqueArc<T> {
     }
 }
 
+// Safety:
+// This leverages the correctness of Arc's CoerciblePtr impl. Additionally, we must ensure that
+// this can not be used to violate the safety invariants of UniqueArc, which require that we can not
+// duplicate the Arc, such that replace_ptr returns a valid instance. This holds since it consumes
+// a unique owner of the contained ArcInner.
 unsafe impl<T, U: ?Sized> unsize::CoerciblePtr<U> for UniqueArc<T> {
     type Pointee = T;
     type Output = UniqueArc<U>;
+
     fn as_sized_ptr(&mut self) -> *mut T {
         // Dispatch to the contained field.
         unsize::CoerciblePtr::<U>::as_sized_ptr(&mut self.0)
     }
+
     unsafe fn replace_ptr(self, new: *mut U) -> UniqueArc<U> {
         // Dispatch to the contained field, work around conflict of destructuring and Drop.
         let inner = mem::ManuallyDrop::new(self);

--- a/src/unique_arc.rs
+++ b/src/unique_arc.rs
@@ -103,6 +103,7 @@ impl<T> DerefMut for UniqueArc<T> {
 // this can not be used to violate the safety invariants of UniqueArc, which require that we can not
 // duplicate the Arc, such that replace_ptr returns a valid instance. This holds since it consumes
 // a unique owner of the contained ArcInner.
+#[cfg(feature = "unsize")]
 unsafe impl<T, U: ?Sized> unsize::CoerciblePtr<U> for UniqueArc<T> {
     type Pointee = T;
     type Output = UniqueArc<U>;


### PR DESCRIPTION
This provides a patch to unsizing some of the pointers of this crate.
The missing cases would require adjustments to offsetting. (Which is
implemented by casting from `*const T` to `*const u8` which causes a
loss of the associated fat pointer tag if any exists.) They may be added 
later.

Fixes: #9 