### PR TITLE
Avoid narrowing provenance through a reference

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,10 +26,16 @@ jobs:
       run: rustup toolchain install nightly --component miri --profile minimal
     - name: Miri Test
       run: cargo +nightly miri test
+      env:
+        MIRIFLAGS: -Zmiri-tag-raw-pointers
     - name: Test --no-default-features
       run: cargo +nightly miri test --no-default-features
+      env:
+        MIRIFLAGS: -Zmiri-tag-raw-pointers
     - name: Test --all-features
       run: cargo +nightly miri test --all-features
+      env:
+        MIRIFLAGS: -Zmiri-tag-raw-pointers
 
   thread_sanitizer:
     runs-on: ubuntu-latest

--- a/src/header.rs
+++ b/src/header.rs
@@ -64,8 +64,8 @@ impl<H, T> Arc<HeaderSlice<H, [T]>> {
             // only to the number of elements in the dynamically-sized portion of
             // the type, so the value will be the same whether it points to a [T]
             // or something else with a [T] as its last member.
-            let fake_slice: &mut [T] = slice::from_raw_parts_mut(buffer as *mut T, num_items);
-            ptr = fake_slice as *mut [T] as *mut ArcInner<HeaderSlice<H, [T]>>;
+            let fake_slice = ptr::slice_from_raw_parts_mut(buffer as *mut T, num_items);
+            ptr = fake_slice as *mut ArcInner<HeaderSlice<H, [T]>>;
 
             let count = atomic::AtomicUsize::new(1);
 
@@ -157,8 +157,8 @@ impl<H, T> Arc<HeaderSlice<H, [T]>> {
             // only to the number of elements in the dynamically-sized portion of
             // the type, so the value will be the same whether it points to a [T]
             // or something else with a [T] as its last member.
-            let fake_slice: &mut [T] = slice::from_raw_parts_mut(buffer as *mut T, num_items);
-            ptr = fake_slice as *mut [T] as *mut ArcInner<HeaderSlice<H, [T]>>;
+            let fake_slice = ptr::slice_from_raw_parts_mut(buffer as *mut T, num_items);
+            ptr = fake_slice as *mut ArcInner<HeaderSlice<H, [T]>>;
 
             let count = atomic::AtomicUsize::new(1);
 

--- a/src/thin_arc.rs
+++ b/src/thin_arc.rs
@@ -43,7 +43,7 @@ fn thin_to_thick<H, T>(
     thin: *mut ArcInner<HeaderSliceWithLength<H, [T; 0]>>,
 ) -> *mut ArcInner<HeaderSliceWithLength<H, [T]>> {
     let len = unsafe { (*thin).data.header.length };
-    let fake_slice: *mut [T] = unsafe { slice::from_raw_parts_mut(thin as *mut T, len) };
+    let fake_slice = ptr::slice_from_raw_parts_mut(thin as *mut T, len);
 
     fake_slice as *mut ArcInner<HeaderSliceWithLength<H, [T]>>
 }


### PR DESCRIPTION
Under Stacked Borrows it is very dangerous to create an intermediate reference in unsafe code. In this case, because provenance does not round-trip through a pointer. The pointer you get out only have provenance over the referent, which is often much less than the original pointer.

One can notice that there is a problem here by running `MIRIFLAGS="-Zmiri-tag-raw-pointers" cargo miri test`. The existing diagnostics are pretty vague, but I'm improving them exactly for situations like this. With my changes and tracking the tag with a problem, one sees:
```
test thin_arc::tests::empty_thin ... note: tracking was triggered
   --> src/header.rs:68:19
    |
68  |             ptr = fake_slice as *mut [T] as *mut ArcInner<HeaderSlice<H, [T]>>;
    |                   ^^^^^^^^^^ created tag 206118, granting SharedReadWrite over alloc77237[0x0..0x0]
    |
    = note: inside `header::<impl arc::Arc<header::HeaderSlice<header::HeaderWithLength<u32>, [i32]>>>::from_header_and_iter::<std::iter::Empty<i32>>` at src/header.rs:68:19
...
<snip>
...
error: Undefined Behavior: trying to reborrow for Unique over alloc77237[0x0..0x8], but parent tag <206118> does not grant the required permission over this memory range
   --> src/header.rs:76:24
    |
76  |             ptr::write(&mut ((*ptr).count), count);
    |                        ^^^^^^^^^^^^^^^^^^^ trying to reborrow for Unique over alloc77237[0x0..0x8], but parent tag <206118> does not grant the required permission over this memory range
    |
```
The problem is that `fake_slice` is an empty slice, so converting it to a pointer gets you a pointer with provenance over no bytes. So this PR creates a raw slice, avoiding the intermediate reference.

(I force-pushed to improve my commit message, I understood the situation only after making the commit that fixes it)