### PR TITLE
Fix provenance issues in as_ptr and new_uninit_slice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 
 [[package]]
 name = "triomphe"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "arc-swap",
  "serde",

--- a/src/arc_swap_support.rs
+++ b/src/arc_swap_support.rs
@@ -2,7 +2,6 @@ use arc_swap::RefCnt;
 
 use crate::{Arc, ThinArc};
 use core::ffi::c_void;
-use core::ptr::NonNull;
 
 unsafe impl<H, T> RefCnt for ThinArc<H, T> {
     type Base = c_void;

--- a/src/header.rs
+++ b/src/header.rs
@@ -3,7 +3,6 @@ use core::iter::{ExactSizeIterator, Iterator};
 use core::marker::PhantomData;
 use core::mem;
 use core::ptr;
-use core::slice;
 use core::sync::atomic;
 use core::usize;
 

--- a/src/thin_arc.rs
+++ b/src/thin_arc.rs
@@ -7,7 +7,6 @@ use core::mem;
 use core::mem::ManuallyDrop;
 use core::ops::Deref;
 use core::ptr;
-use core::slice;
 use core::usize;
 
 use super::{Arc, ArcInner, HeaderSliceWithLength, HeaderWithLength};


### PR DESCRIPTION
Fixes https://github.com/Manishearth/triomphe/issues/38

The root cause of these changes is the same: we need to avoid round-tripping pointers through a reference to the Arc's `T` so that we can use said pointer to access the metadata/reference count.

I also apologize for not catching these earlier. I have a whole dashboard of crates that don't pass Miri and I should have noticed that even after you released 0.1.6 that triomphe still appeared through the dependent crate mentioned in #38. 