### PR TITLE
Fix UB in `Arc::<MaybeUninit<_>>::write`

### DIFF
--- a/src/arc.rs
+++ b/src/arc.rs
@@ -659,6 +659,7 @@ mod tests {
     use core::mem::MaybeUninit;
     #[cfg(feature = "unsize")]
     use unsize::{CoerceUnsize, Coercion};
+    use alloc::string::String;
 
     #[test]
     fn try_unwrap() {


### PR DESCRIPTION
Previously `write` would write even to a shared `Arc` which caused UB, as demonstrated by the `maybeuninit_ub_to_proceed` test.

This PR makes `write` panic on non-unique `Arc`s and adds similar functionality to `UniqueArc` where it's always safe.

Fixes #41