### PR TITLE
Implement `From<...>` for `Arc`

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -337,6 +337,14 @@ mod tests {
     }
 
     #[test]
+    fn from_header_and_vec_smoke() {
+        let arc = Arc::from_header_and_vec((42u32, 17u8), vec![1u16, 2, 3, 4, 5, 6, 7]);
+
+        assert_eq!(arc.header, (42, 17));
+        assert_eq!(arc.slice, [1u16, 2, 3, 4, 5, 6, 7]);
+    }
+
+    #[test]
     fn from_header_and_iter_empty() {
         let arc = Arc::from_header_and_iter((42u32, 17u8), iter::empty::<u16>());
 
@@ -347,6 +355,14 @@ mod tests {
     #[test]
     fn from_header_and_slice_empty() {
         let arc = Arc::from_header_and_slice((42u32, 17u8), &[1u16; 0]);
+
+        assert_eq!(arc.header, (42, 17));
+        assert_eq!(arc.slice, []);
+    }
+
+    #[test]
+    fn from_header_and_vec_empty() {
+        let arc = Arc::from_header_and_vec((42u32, 17u8), vec![1u16; 0]);
 
         assert_eq!(arc.header, (42, 17));
         assert_eq!(arc.slice, []);

--- a/src/header.rs
+++ b/src/header.rs
@@ -224,6 +224,24 @@ impl<T: ?Sized> From<Arc<T>> for Arc<HeaderSlice<(), T>> {
     }
 }
 
+impl<T: Copy> From<&[T]> for Arc<[T]> {
+    fn from(slice: &[T]) -> Self {
+        Arc::from_header_and_slice((), slice).into()
+    }
+}
+
+impl From<&str> for Arc<str> {
+    fn from(s: &str) -> Self {
+        Arc::from_header_and_str((), s).into()
+    }
+}
+
+impl From<String> for Arc<str> {
+    fn from(s: String) -> Self {
+        Self::from(&s[..])
+    }
+}
+
 pub(crate) type HeaderSliceWithLength<H, T> = HeaderSlice<HeaderWithLength<H>, T>;
 
 #[cfg(test)]

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,4 +1,7 @@
 use alloc::alloc::Layout;
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
 use core::iter::{ExactSizeIterator, Iterator};
 use core::marker::PhantomData;
 use core::mem::{self, ManuallyDrop};
@@ -252,6 +255,9 @@ pub(crate) type HeaderSliceWithLength<H, T> = HeaderSlice<HeaderWithLength<H>, T
 
 #[cfg(test)]
 mod tests {
+    use alloc::boxed::Box;
+    use alloc::string::String;
+    use alloc::vec;
     use core::iter;
 
     use crate::{Arc, HeaderSlice};

--- a/src/header.rs
+++ b/src/header.rs
@@ -2,8 +2,7 @@ use alloc::alloc::Layout;
 use core::iter::{ExactSizeIterator, Iterator};
 use core::marker::PhantomData;
 use core::mem;
-use core::ptr;
-use core::sync::atomic;
+use core::ptr::{self, NonNull};
 use core::usize;
 
 use super::{Arc, ArcInner};
@@ -36,47 +35,40 @@ impl<H, T> Arc<HeaderSlice<H, [T]>> {
         let data_to_slice_offset = offset_of!(HeaderSlice<H, [T; 0]>, slice);
         let slice_offset = inner_to_data_offset + data_to_slice_offset;
 
-        // Compute the size of the real payload.
-        let slice_size = mem::size_of::<T>()
-            .checked_mul(num_items)
-            .expect("size overflows");
-        let usable_size = slice_offset
-            .checked_add(slice_size)
-            .expect("size overflows");
+        let ptr: NonNull<ArcInner<HeaderSlice<H, [T]>>> = unsafe {
+            let layout = Layout::new::<H>()
+                .extend(Layout::array::<T>(num_items).unwrap())
+                .unwrap()
+                .0
+                .pad_to_align();
 
-        // Round up size to alignment.
-        let align = mem::align_of::<ArcInner<HeaderSlice<H, [T; 0]>>>();
-        let size = usable_size.wrapping_add(align - 1) & !(align - 1);
-        assert!(size >= usable_size, "size overflows");
-        let layout = Layout::from_size_align(size, align).expect("invalid layout");
+            // Safety:
+            // - the provided closure does not change the pointer (except for meta & type)
+            // - the provided layout is valid for `HeaderSlice<H, [T]>`
+            Arc::allocate_for_layout(layout, |mem| {
+                // Synthesize the fat pointer. We do this by claiming we have a direct
+                // pointer to a [T], and then changing the type of the borrow. The key
+                // point here is that the length portion of the fat pointer applies
+                // only to the number of elements in the dynamically-sized portion of
+                // the type, so the value will be the same whether it points to a [T]
+                // or something else with a [T] as its last member.
+                let fake_slice = ptr::slice_from_raw_parts_mut(mem as *mut T, num_items);
+                fake_slice as *mut ArcInner<HeaderSlice<H, [T]>>
+            })
+        };
 
-        let ptr: *mut ArcInner<HeaderSlice<H, [T]>>;
         unsafe {
-            let buffer = alloc::alloc::alloc(layout);
-            if buffer.is_null() {
-                alloc::alloc::handle_alloc_error(layout);
-            }
-
-            // Synthesize the fat pointer. We do this by claiming we have a direct
-            // pointer to a [T], and then changing the type of the borrow. The key
-            // point here is that the length portion of the fat pointer applies
-            // only to the number of elements in the dynamically-sized portion of
-            // the type, so the value will be the same whether it points to a [T]
-            // or something else with a [T] as its last member.
-            let fake_slice = ptr::slice_from_raw_parts_mut(buffer as *mut T, num_items);
-            ptr = fake_slice as *mut ArcInner<HeaderSlice<H, [T]>>;
-
-            let count = atomic::AtomicUsize::new(1);
-
             // Write the data.
             //
             // Note that any panics here (i.e. from the iterator) are safe, since
             // we'll just leak the uninitialized memory.
-            ptr::write(&mut ((*ptr).count), count);
-            ptr::write(&mut ((*ptr).data.header), header);
+            ptr::write(&mut ((*ptr.as_ptr()).data.header), header);
             if num_items != 0 {
-                let mut current = (*ptr).data.slice.as_mut_ptr();
-                debug_assert_eq!(current as usize - buffer as usize, slice_offset);
+                let mut current = (*ptr.as_ptr()).data.slice.as_mut_ptr();
+                debug_assert_eq!(
+                    current as usize - ptr.as_ptr() as *mut u8 as usize,
+                    slice_offset
+                );
                 for _ in 0..num_items {
                     ptr::write(
                         current,
@@ -90,9 +82,6 @@ impl<H, T> Arc<HeaderSlice<H, [T]>> {
                     items.next().is_none(),
                     "ExactSizeIterator under-reported length"
                 );
-
-                // We should have consumed the buffer exactly.
-                debug_assert_eq!(current as *mut u8, buffer.add(usable_size));
             }
             assert!(
                 items.next().is_none(),
@@ -100,11 +89,10 @@ impl<H, T> Arc<HeaderSlice<H, [T]>> {
             );
         }
 
-        unsafe {
-            Arc {
-                p: ptr::NonNull::new_unchecked(ptr),
-                phantom: PhantomData,
-            }
+        // Safety: ptr is valid & the inner structure is fully initialized
+        Arc {
+            p: ptr,
+            phantom: PhantomData,
         }
     }
 
@@ -118,55 +106,39 @@ impl<H, T> Arc<HeaderSlice<H, [T]>> {
 
         let num_items = items.len();
 
-        // Offset of the start of the slice in the allocation.
-        let inner_to_data_offset = offset_of!(ArcInner<HeaderSlice<H, [T; 0]>>, data);
-        let data_to_slice_offset = offset_of!(HeaderSlice<H, [T; 0]>, slice);
-        let slice_offset = inner_to_data_offset + data_to_slice_offset;
+        let ptr: NonNull<ArcInner<HeaderSlice<H, [T]>>> = unsafe {
+            let layout = Layout::new::<H>()
+                .extend(Layout::for_value::<[T]>(items))
+                .unwrap()
+                .0
+                .pad_to_align();
 
-        // Compute the size of the real payload.
-        let slice_size = mem::size_of::<T>()
-            .checked_mul(num_items)
-            .expect("size overflows");
-        let usable_size = slice_offset
-            .checked_add(slice_size)
-            .expect("size overflows");
+            // Safety:
+            // - the provided closure does not change the pointer (except for meta & type)
+            // - the provided layout is valid for `HeaderSlice<H, [T]>`
+            Arc::allocate_for_layout(layout, |mem| {
+                // Synthesize the fat pointer. We do this by claiming we have a direct
+                // pointer to a [T], and then changing the type of the borrow. The key
+                // point here is that the length portion of the fat pointer applies
+                // only to the number of elements in the dynamically-sized portion of
+                // the type, so the value will be the same whether it points to a [T]
+                // or something else with a [T] as its last member.
+                let fake_slice = ptr::slice_from_raw_parts_mut(mem as *mut T, num_items);
+                fake_slice as *mut ArcInner<HeaderSlice<H, [T]>>
+            })
+        };
 
-        // Round up size to alignment.
-        let align = mem::align_of::<ArcInner<HeaderSlice<H, [T; 0]>>>();
-        let size = usable_size.wrapping_add(align - 1) & !(align - 1);
-        assert!(size >= usable_size, "size overflows");
-        let layout = Layout::from_size_align(size, align).expect("invalid layout");
-
-        let ptr: *mut ArcInner<HeaderSlice<H, [T]>>;
         unsafe {
-            let buffer = alloc::alloc::alloc(layout);
-            if buffer.is_null() {
-                alloc::alloc::handle_alloc_error(layout);
-            }
-
-            // Synthesize the fat pointer. We do this by claiming we have a direct
-            // pointer to a [T], and then changing the type of the borrow. The key
-            // point here is that the length portion of the fat pointer applies
-            // only to the number of elements in the dynamically-sized portion of
-            // the type, so the value will be the same whether it points to a [T]
-            // or something else with a [T] as its last member.
-            let fake_slice = ptr::slice_from_raw_parts_mut(buffer as *mut T, num_items);
-            ptr = fake_slice as *mut ArcInner<HeaderSlice<H, [T]>>;
-
-            let count = atomic::AtomicUsize::new(1);
-
             // Write the data.
-            ptr::write(&mut ((*ptr).count), count);
-            ptr::write(&mut ((*ptr).data.header), header);
-            let current = (*ptr).data.slice.as_mut_ptr();
-            ptr::copy_nonoverlapping(items.as_ptr(), current, num_items);
+            ptr::write(&mut ((*ptr.as_ptr()).data.header), header);
+            let dst = (*ptr.as_ptr()).data.slice.as_mut_ptr();
+            ptr::copy_nonoverlapping(items.as_ptr(), dst, num_items);
         }
 
-        unsafe {
-            Arc {
-                p: ptr::NonNull::new_unchecked(ptr),
-                phantom: PhantomData,
-            }
+        // Safety: ptr is valid & the inner structure is fully initialized
+        Arc {
+            p: ptr,
+            phantom: PhantomData,
         }
     }
 }


### PR DESCRIPTION
This implements most of the #12.

Missing impls:
- `From<&CStr>`, `From<CString>`, `From<&OsStr>`, `From<OsString>`, `From<&Path>`, `From<PathBuf>` (all these types are quite opaque, so I'm not sure how to work with them)
- `From<Arc<W>> for {Raw,}Waker` (`Wake` trait uses `std::sync::Arc` so there is no reason to implement these impls)