### PR TITLE
Mute warning

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -235,7 +235,7 @@ impl<T> From<Box<T>> for Arc<T> {
             // Safety:
             // - `src` has been got from `Box::into_raw`
             // - `ManuallyDrop<T>` is guaranteed to have the same layout as `T`
-            Box::<ManuallyDrop<T>>::from_raw(src as _);
+            drop(Box::<ManuallyDrop<T>>::from_raw(src as _));
         }
 
         Arc {


### PR DESCRIPTION
The warning was:

```
warning: unused return value of `Box::<T>::from_raw` that must be used
   --> src/header.rs:238:13
    |
238 |             Box::<ManuallyDrop<T>>::from_raw(src as _);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: call `drop(from_raw(ptr))` if you intend to drop the `Box`
    = note: `#[warn(unused_must_use)]` on by default
```