### PR TITLE
Fix accidental html tags in docs using `Arc<T>` with generic argument

### DIFF
--- a/src/arc.rs
+++ b/src/arc.rs
@@ -29,7 +29,7 @@ use crate::{abort, ArcBorrow, HeaderSlice, OffsetArc, UniqueArc};
 /// necessarily) at _exactly_ `MAX_REFCOUNT + 1` references.
 const MAX_REFCOUNT: usize = (isize::MAX) as usize;
 
-/// The object allocated by an Arc<T>
+/// The object allocated by an `Arc<T>`
 #[repr(C)]
 pub(crate) struct ArcInner<T: ?Sized> {
     pub(crate) count: atomic::AtomicUsize,
@@ -71,7 +71,7 @@ impl<T> Arc<T> {
         }
     }
 
-    /// Reconstruct the Arc<T> from a raw pointer obtained from into_raw()
+    /// Reconstruct the `Arc<T>` from a raw pointer obtained from into_raw()
     ///
     /// Note: This raw pointer will be offset in the allocation and must be preceded
     /// by the atomic count.
@@ -165,7 +165,7 @@ impl<T> Arc<[T]> {
 }
 
 impl<T: ?Sized> Arc<T> {
-    /// Convert the Arc<T> to a raw pointer, suitable for use across FFI
+    /// Convert the `Arc<T>` to a raw pointer, suitable for use across FFI
     ///
     /// Note: This returns a pointer to the data T, which is offset in the allocation.
     ///

--- a/src/unique_arc.rs
+++ b/src/unique_arc.rs
@@ -81,7 +81,7 @@ impl<T> UniqueArc<T> {
 }
 
 impl<T: ?Sized> UniqueArc<T> {
-    /// Convert to a shareable Arc<T> once we're done mutating it
+    /// Convert to a shareable `Arc<T>` once we're done mutating it
     #[inline]
     pub fn shareable(self) -> Arc<T> {
         self.0


### PR DESCRIPTION
I noticed this from warnings about “unclosed HTML tags” when building docs locally. This resulted in docs like [this](https://docs.rs/triomphe/0.1.9/triomphe/struct.Arc.html#method.from_raw) being rendered with `Arc` instead of `Arc<T>` ([source](https://docs.rs/triomphe/0.1.9/src/triomphe/arc.rs.html#74-79)).