### PR TITLE
Add test that actually uses `ArcBorrow`

### DIFF
--- a/src/arc_borrow.rs
+++ b/src/arc_borrow.rs
@@ -114,3 +114,11 @@ unsafe impl<'lt, T: 'lt, U: ?Sized + 'lt> unsize::CoerciblePtr<U> for ArcBorrow<
         ArcBorrow(inner.0.replace_ptr(new))
     }
 }
+
+#[test]
+fn clone_arc_borrow() {
+    let x = Arc::new(42);
+    let b: ArcBorrow<'_, i32> = x.borrow_arc();
+    let y = b.clone_arc();
+    assert_eq!(x, y);
+}


### PR DESCRIPTION
When run with miri, this demonstrates UB in the current implementation, due to provenance of references. See (TODO open issue).