### PR TITLE
Stop exporting development files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+/.editorconfig export-ignore
+/.github/ export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore


### PR DESCRIPTION
GitHub ZIP-s and services downloading it won't contain development files in production.
