### PR TITLE
Add safety sections, fix clippy warnings

### DIFF
--- a/src/arc_borrow.rs
+++ b/src/arc_borrow.rs
@@ -46,6 +46,8 @@ impl<'a, T> ArcBorrow<'a, T> {
     /// e.g. if we obtain such a reference over FFI
     /// TODO: should from_ref be relaxed to unsized types? It can't be
     /// converted back to an Arc right now for unsized types.
+    /// # Safety
+    /// - The reference to `T` must have come from a Triomphe Arc, UniqueArc, or ArcBorrow.
     #[inline]
     pub unsafe fn from_ref(r: &'a T) -> Self {
         ArcBorrow(r)

--- a/src/arc_borrow.rs
+++ b/src/arc_borrow.rs
@@ -46,9 +46,6 @@ impl<'a, T> ArcBorrow<'a, T> {
     /// e.g. if we obtain such a reference over FFI
     /// TODO: should from_ref be relaxed to unsized types? It can't be
     /// converted back to an Arc right now for unsized types.
-    ///
-    ///  # Safety
-    /// - The reference to `T` must be valid
     #[inline]
     pub unsafe fn from_ref(r: &'a T) -> Self {
         ArcBorrow(r)

--- a/src/arc_borrow.rs
+++ b/src/arc_borrow.rs
@@ -46,6 +46,9 @@ impl<'a, T> ArcBorrow<'a, T> {
     /// e.g. if we obtain such a reference over FFI
     /// TODO: should from_ref be relaxed to unsized types? It can't be
     /// converted back to an Arc right now for unsized types.
+    ///
+    ///  # Safety
+    /// - The reference to `T` must be valid
     #[inline]
     pub unsafe fn from_ref(r: &'a T) -> Self {
         ArcBorrow(r)

--- a/src/unique_arc.rs
+++ b/src/unique_arc.rs
@@ -108,7 +108,7 @@ impl<T: ?Sized> UniqueArc<T> {
     ///
     /// The given `Arc` must have a reference count of exactly one
     pub(crate) unsafe fn from_arc_ref(arc: &mut Arc<T>) -> &mut Self {
-        debug_assert_eq!(Arc::count(&arc), 1);
+        debug_assert_eq!(Arc::count(arc), 1);
 
         // Safety: caller guarantees that `arc` is unique,
         //         `UniqueArc` is `repr(transparent)`
@@ -191,7 +191,7 @@ impl<T: ?Sized> Deref for UniqueArc<T> {
 
     #[inline]
     fn deref(&self) -> &T {
-        &*self.0
+        &self.0
     }
 }
 


### PR DESCRIPTION
As described above, I added safety sections to the docs and fixed the clippy warnings.