### PR TITLE
chore: bump to 0.1.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "triomphe"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Manishearth/triomphe"


### PR DESCRIPTION
Doing a version bump as per https://github.com/Manishearth/triomphe/pull/58#issuecomment-1826082098.