### PR TITLE
Remove length check from ThinSlice::clone to halve generated code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "triomphe"
-version = "0.1.9"
+version = "0.1.10"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Manishearth/triomphe"


### PR DESCRIPTION
Remove length check from `ThinSlice::clone`. This check doubles the size of the function generated code. Since `ThinSlice::clone` is inlined everywhere this can improve codegen significantly.

Includes a commit bumping the version to 0.1.10.


Asm before
```asm
        .cfi_startproc
        sub rsp, 56
        .cfi_def_cfa_offset 64

        mov rax, qword ptr [rdi]

        mov rcx, qword ptr [rax + 8]

        lock inc        qword ptr [rax]

        jle .LBB366_3

        mov qword ptr [rsp], rcx

        cmp qword ptr [rax + 8], rcx

        jne .LBB366_4

        add rsp, 56
        .cfi_def_cfa_offset 8
        ret

.LBB366_3:
        .cfi_def_cfa_offset 64
        call qword ptr [rip + std::process::abort@GOTPCREL]

        ud2

.LBB366_4:
        lea rcx, [rip + .L__unnamed_289]

        mov qword ptr [rsp + 8], rcx
        mov qword ptr [rsp + 16], 1
        mov qword ptr [rsp + 24], 0
        lea rcx, [rip + .L__unnamed_183]
        mov qword ptr [rsp + 40], rcx
        mov qword ptr [rsp + 48], 0
        add rax, 8

        mov rsi, rsp
        lea rdx, [rsp + 8]
        mov rdi, rax

        call core::panicking::assert_failed
        ud2
```