### PR TITLE
Fix arc borrow provenance of, and add a test that actually uses `ArcBorrow`

### DIFF
--- a/src/arc.rs
+++ b/src/arc.rs
@@ -202,7 +202,12 @@ impl<T: ?Sized> Arc<T> {
     /// and can be converted into more `Arc<T>`s if necessary.
     #[inline]
     pub fn borrow_arc(&self) -> ArcBorrow<'_, T> {
-        ArcBorrow(&**self)
+        unsafe {
+            ArcBorrow(
+                NonNull::new_unchecked(self.as_ptr().cast_mut()),
+                PhantomData,
+            )
+        }
     }
 
     /// Returns the address on the heap of the Arc itself -- not the T within it -- for memory

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -202,12 +202,7 @@ impl<T: ?Sized> Arc<T> {
     /// and can be converted into more `Arc<T>`s if necessary.
     #[inline]
     pub fn borrow_arc(&self) -> ArcBorrow<'_, T> {
-        unsafe {
-            ArcBorrow(
-                NonNull::new_unchecked(self.as_ptr().cast_mut()),
-                PhantomData,
-            )
-        }
+        unsafe { ArcBorrow(NonNull::new_unchecked(self.as_ptr() as *mut T), PhantomData) }
     }
 
     /// Returns the address on the heap of the Arc itself -- not the T within it -- for memory

--- a/src/arc_borrow.rs
+++ b/src/arc_borrow.rs
@@ -58,7 +58,7 @@ impl<'a, T> ArcBorrow<'a, T> {
     ///   [`Arc::as_ptr`].
     #[inline]
     pub unsafe fn from_ptr(ptr: *const T) -> Self {
-        unsafe { ArcBorrow(NonNull::new_unchecked(ptr.cast_mut()), PhantomData) }
+        unsafe { ArcBorrow(NonNull::new_unchecked(ptr as *mut T), PhantomData) }
     }
 
     /// Compare two `ArcBorrow`s via pointer equality. Will only return
@@ -88,7 +88,7 @@ impl<'a, T> ArcBorrow<'a, T> {
     /// self, which is incompatible with the signature of the Deref trait.
     #[inline]
     pub fn get(&self) -> &'a T {
-        unsafe { self.0.as_ref() }
+        unsafe { &*self.0.as_ptr() }
     }
 }
 
@@ -97,7 +97,7 @@ impl<'a, T> Deref for ArcBorrow<'a, T> {
 
     #[inline]
     fn deref(&self) -> &T {
-        unsafe { self.0.as_ref() }
+        self.get()
     }
 }
 

--- a/src/arc_borrow.rs
+++ b/src/arc_borrow.rs
@@ -116,3 +116,11 @@ unsafe impl<'lt, T: 'lt, U: ?Sized + 'lt> unsize::CoerciblePtr<U> for ArcBorrow<
         ArcBorrow(inner.0.replace_ptr(new))
     }
 }
+
+#[test]
+fn clone_arc_borrow() {
+    let x = Arc::new(42);
+    let b: ArcBorrow<'_, i32> = x.borrow_arc();
+    let y = b.clone_arc();
+    assert_eq!(x, y);
+}

--- a/src/arc_borrow.rs
+++ b/src/arc_borrow.rs
@@ -25,6 +25,9 @@ use super::Arc;
 #[repr(transparent)]
 pub struct ArcBorrow<'a, T: ?Sized + 'a>(pub(crate) NonNull<T>, pub(crate) PhantomData<&'a T>);
 
+unsafe impl<'a, T: ?Sized + Sync + Send> Send for ArcBorrow<'a, T> {}
+unsafe impl<'a, T: ?Sized + Sync + Send> Sync for ArcBorrow<'a, T> {}
+
 impl<'a, T> Copy for ArcBorrow<'a, T> {}
 impl<'a, T> Clone for ArcBorrow<'a, T> {
     #[inline]

--- a/src/arc_borrow.rs
+++ b/src/arc_borrow.rs
@@ -116,15 +116,13 @@ unsafe impl<'lt, T: 'lt, U: ?Sized + 'lt> unsize::CoerciblePtr<U> for ArcBorrow<
     type Output = ArcBorrow<'lt, U>;
 
     fn as_sized_ptr(&mut self) -> *mut T {
-        // Returns a pointer to the inner data. We do not need to care about any particular
-        // provenance here, only the pointer value, which we need to reconstruct the new pointer.
-        self.0 as *const T as *mut T
+        self.0.as_ptr()
     }
 
     unsafe fn replace_ptr(self, new: *mut U) -> ArcBorrow<'lt, U> {
         let inner = ManuallyDrop::new(self);
         // Safety: backed by the same Arc that backed `self`.
-        ArcBorrow(inner.0.replace_ptr(new))
+        ArcBorrow(inner.0.replace_ptr(new), PhantomData)
     }
 }
 

--- a/src/arc_union.rs
+++ b/src/arc_union.rs
@@ -60,11 +60,11 @@ impl<A, B> ArcUnion<A, B> {
     pub fn borrow(&self) -> ArcUnionBorrow<A, B> {
         if self.is_first() {
             let ptr = self.p.as_ptr() as *const A;
-            let borrow = unsafe { ArcBorrow::from_ref(&*ptr) };
+            let borrow = unsafe { ArcBorrow::from_ptr(ptr) };
             ArcUnionBorrow::First(borrow)
         } else {
             let ptr = ((self.p.as_ptr() as usize) & !0x1) as *const B;
-            let borrow = unsafe { ArcBorrow::from_ref(&*ptr) };
+            let borrow = unsafe { ArcBorrow::from_ptr(ptr) };
             ArcUnionBorrow::Second(borrow)
         }
     }

--- a/src/offset_arc.rs
+++ b/src/offset_arc.rs
@@ -133,6 +133,6 @@ impl<T> OffsetArc<T> {
     /// to an `Arc`
     #[inline]
     pub fn borrow_arc(&self) -> ArcBorrow<'_, T> {
-        ArcBorrow(&**self)
+        ArcBorrow(self.ptr, PhantomData)
     }
 }


### PR DESCRIPTION
This PR also had to remove the `ArcBorrow::from_ref` API since it was unconditionally unsound to ever use.

Further breakage is in the former `Send`/`Sync` implementation, as this fixes #66

Fixes #65.

This PR supersedes #64. Sorry for the long delay 😅 