### PR TITLE
Lift the `T: 'static` bound from `ArcBorrow::with_arc`

### DIFF
--- a/src/arc_borrow.rs
+++ b/src/arc_borrow.rs
@@ -66,7 +66,6 @@ impl<'a, T> ArcBorrow<'a, T> {
     pub fn with_arc<F, U>(&self, f: F) -> U
     where
         F: FnOnce(&Arc<T>) -> U,
-        T: 'static,
     {
         // Synthesize transient Arc, which never touches the refcount.
         let transient = unsafe { ManuallyDrop::new(Arc::from_raw(self.0)) };


### PR DESCRIPTION
closes #79