### PR TITLE
*::strong_count

### DIFF
--- a/src/arc_borrow.rs
+++ b/src/arc_borrow.rs
@@ -71,6 +71,19 @@ impl<'a, T> ArcBorrow<'a, T> {
         this.0 == other.0
     }
 
+    /// The reference count of the underlying `Arc`.
+    ///
+    /// The number does not include borrowed pointers,
+    /// or temporary `Arc` pointers created with functions like
+    /// [`ArcBorrow::with_arc`].
+    ///
+    /// The function is called `strong_count` to mirror `std::sync::Arc::strong_count`,
+    /// however `triomphe::Arc` does not support weak references.
+    #[inline]
+    pub fn strong_count(this: &Self) -> usize {
+        Self::with_arc(this, |arc| Arc::strong_count(arc))
+    }
+
     /// Temporarily converts |self| into a bonafide Arc and exposes it to the
     /// provided callback. The refcount is not modified.
     #[inline]

--- a/src/arc_union.rs
+++ b/src/arc_union.rs
@@ -56,6 +56,12 @@ impl<A, B> ArcUnion<A, B> {
         this.p == other.p
     }
 
+    /// Reference count.
+    #[inline]
+    pub fn strong_count(this: &Self) -> usize {
+        ArcUnionBorrow::strong_count(&this.borrow())
+    }
+
     /// Returns an enum representing a borrow of either A or B.
     pub fn borrow(&self) -> ArcUnionBorrow<A, B> {
         if self.is_first() {
@@ -135,5 +141,23 @@ impl<A, B> Drop for ArcUnion<A, B> {
 impl<A: fmt::Debug, B: fmt::Debug> fmt::Debug for ArcUnion<A, B> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(&self.borrow(), f)
+    }
+}
+
+impl<'a, A, B> ArcUnionBorrow<'a, A, B> {
+    /// The reference count of this `Arc`.
+    ///
+    /// The number does not include borrowed pointers,
+    /// or temporary `Arc` pointers created with functions like
+    /// [`ArcBorrow::with_arc`].
+    ///
+    /// The function is called `strong_count` to mirror `std::sync::Arc::strong_count`,
+    /// however `triomphe::Arc` does not support weak references.
+    #[inline]
+    pub fn strong_count(this: &Self) -> usize {
+        match this {
+            ArcUnionBorrow::First(arc) => ArcBorrow::strong_count(arc),
+            ArcUnionBorrow::Second(arc) => ArcBorrow::strong_count(arc),
+        }
     }
 }

--- a/src/offset_arc.rs
+++ b/src/offset_arc.rs
@@ -135,4 +135,17 @@ impl<T> OffsetArc<T> {
     pub fn borrow_arc(&self) -> ArcBorrow<'_, T> {
         ArcBorrow(self.ptr, PhantomData)
     }
+
+    /// The reference count of this `Arc`.
+    ///
+    /// The number does not include borrowed pointers,
+    /// or temporary `Arc` pointers created with functions like
+    /// [`ArcBorrow::with_arc`].
+    ///
+    /// The function is called `strong_count` to mirror `std::sync::Arc::strong_count`,
+    /// however `triomphe::Arc` does not support weak references.
+    #[inline]
+    pub fn strong_count(this: &Self) -> usize {
+        Self::with_arc(this, |arc| Arc::strong_count(arc))
+    }
 }

--- a/src/thin_arc.rs
+++ b/src/thin_arc.rs
@@ -8,6 +8,7 @@ use core::mem::ManuallyDrop;
 use core::ops::Deref;
 use core::ptr;
 use core::usize;
+use ArcBorrow;
 
 use super::{Arc, ArcInner, HeaderSliceWithLength, HeaderWithLength};
 
@@ -135,6 +136,19 @@ impl<H, T> ThinArc<H, T> {
     #[inline]
     pub fn as_ptr(&self) -> *const c_void {
         self.ptr()
+    }
+
+    /// The reference count of this `Arc`.
+    ///
+    /// The number does not include borrowed pointers,
+    /// or temporary `Arc` pointers created with functions like
+    /// [`ArcBorrow::with_arc`].
+    ///
+    /// The function is called `strong_count` to mirror `std::sync::Arc::strong_count`,
+    /// however `triomphe::Arc` does not support weak references.
+    #[inline]
+    pub fn strong_count(this: &Self) -> usize {
+        Self::with_arc(this, |arc| Arc::strong_count(arc))
     }
 }
 


### PR DESCRIPTION
API similar to `std::sync::Arc`.

`ArcBorrow::strong_count` is made to take `&Self` rather than `Self` for consistency with `ArcBorrow::ptr_eq`, although I think by value might be more appropriate. Maybe change everything in version 0.2?