### PR TITLE
Use ptr::addr_eq instead of == in Arc::ptr_eq

### DIFF
--- a/src/arc.rs
+++ b/src/arc.rs
@@ -257,11 +257,11 @@ impl<T: ?Sized> Arc<T> {
         let _ = Box::from_raw(self.ptr());
     }
 
-    /// Test pointer equality between the two Arcs, i.e. they must be the _same_
-    /// allocation
+    /// Returns `true` if the two `Arc`s point to the same allocation in a vein similar to
+    /// [`ptr::eq`]. This function ignores the metadata of  `dyn Trait` pointers.
     #[inline]
     pub fn ptr_eq(this: &Self, other: &Self) -> bool {
-        this.ptr() == other.ptr()
+        ptr::addr_eq(this.ptr(), other.ptr())
     }
 
     pub(crate) fn ptr(&self) -> *mut ArcInner<T> {


### PR DESCRIPTION
- This is what `std::sync::Arc` does

https://github.com/rust-lang/rust/blob/38104f3a8838f8662ad3cccc4d7262a96bf9724e/library/alloc/src/sync.rs#L1841-L1843

- This is behavior change
- Previous behavior was unreliable because compiler could merge/duplicate vtables
- Doing mostly to reduce the number of compiler warnings
- New code requires Rust >= 1.76.0