### PR TITLE
Simplify/fix Arc::from_iter

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -42,21 +42,15 @@ impl<H, T> Arc<HeaderSlice<H, [T]>> {
             // Note that any panics here (i.e. from the iterator) are safe, since
             // we'll just leak the uninitialized memory.
             ptr::write(&mut ((*inner.as_ptr()).data.header), header);
-            if num_items != 0 {
-                let mut current = (*inner.as_ptr()).data.slice.as_mut_ptr();
-                for _ in 0..num_items {
-                    ptr::write(
-                        current,
-                        items
-                            .next()
-                            .expect("ExactSizeIterator over-reported length"),
-                    );
-                    current = current.offset(1);
-                }
-                assert!(
-                    items.next().is_none(),
-                    "ExactSizeIterator under-reported length"
+            let mut current = (*inner.as_ptr()).data.slice.as_mut_ptr();
+            for _ in 0..num_items {
+                ptr::write(
+                    current,
+                    items
+                        .next()
+                        .expect("ExactSizeIterator over-reported length"),
                 );
+                current = current.offset(1);
             }
             assert!(
                 items.next().is_none(),


### PR DESCRIPTION
When exact size iterator is not empty, `.next()` is called twice after iteration ends, and the second call is allowed to return `Some` for non-fused iterator.

Also less code, and probably faster because fewer branches and smaller binary size.