### PR TITLE
Add UniqueArc::from_header_and_uninit_slice

### DIFF
--- a/src/unique_arc.rs
+++ b/src/unique_arc.rs
@@ -183,6 +183,33 @@ impl<T> UniqueArc<[MaybeUninit<T>]> {
     }
 }
 
+impl<H, T> UniqueArc<HeaderSlice<H, [MaybeUninit<T>]>> {
+    /// Creates an Arc for a HeaderSlice using the given header struct and allocated space
+    /// for an unitialized slice of length `len`.
+    pub fn from_header_and_uninit_slice(header: H, len: usize) -> Self {
+        let inner = Arc::allocate_for_header_and_slice(len);
+
+        unsafe {
+            // Write the header.
+            ptr::write(&mut ((*inner.as_ptr()).data.header), header);
+        }
+
+        // Safety: ptr is valid & the inner structure is fully initialized
+        Self(Arc {
+            p: inner,
+            phantom: PhantomData,
+        })
+    }
+
+    /// # Safety
+    ///
+    /// Must initialize all fields before calling this function.
+    #[inline]
+    pub unsafe fn assume_init_slice_with_header(self) -> UniqueArc<HeaderSlice<H, [T]>> {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+
 impl<T: ?Sized> TryFrom<Arc<T>> for UniqueArc<T> {
     type Error = Arc<T>;
 
@@ -248,7 +275,7 @@ unsafe impl<T, U: ?Sized> unsize::CoerciblePtr<U> for UniqueArc<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Arc, UniqueArc};
+    use crate::{Arc, HeaderSliceWithLength, HeaderWithLength, UniqueArc};
     use core::{convert::TryFrom, mem::MaybeUninit};
 
     #[test]
@@ -277,5 +304,39 @@ mod tests {
 
         let arc = unsafe { UniqueArc::assume_init(arc) };
         assert_eq!(*arc, 999);
+    }
+
+    #[test]
+    fn from_header_and_uninit_slice() {
+        let mut uarc: UniqueArc<HeaderSliceWithLength<u8, [MaybeUninit<u16>]>> =
+            UniqueArc::from_header_and_uninit_slice(HeaderWithLength::new(1, 3), 3);
+        uarc.slice.fill(MaybeUninit::new(2));
+        let arc = unsafe { uarc.assume_init_slice_with_header() }.shareable();
+        assert!(arc.is_unique());
+        // Using clone to that the layout generated in new_uninit_slice is compatible
+        // with ArcInner.
+        let arcs = [
+            arc.clone(),
+            arc.clone(),
+            arc.clone(),
+            arc.clone(),
+            arc.clone(),
+        ];
+        // Similar for ThinArc
+        let thin = Arc::into_thin(arc.clone());
+        assert_eq!(7, Arc::count(&arc));
+        // If the layout is not compatible, then the data might be corrupted.
+        assert_eq!(arc.header.header, 1);
+        assert_eq!(&arc.slice, [2, 2, 2]);
+        assert_eq!(thin.header.header, 1);
+        assert_eq!(&thin.slice, [2, 2, 2]);
+
+        // Drop the arcs and check the count and the content to
+        // make sure it isn't corrupted.
+        drop(arcs);
+        drop(thin);
+        assert!(arc.is_unique());
+        assert_eq!(arc.header.header, 1);
+        assert_eq!(&arc.slice, [2, 2, 2]);
     }
 }


### PR DESCRIPTION
It allows data to be read directly into what will become a ThinArc.