### PR TITLE
Add may_dangle to Arc::drop conditionally

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,6 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -14,6 +13,8 @@ jobs:
           - nightly
     steps:
     - uses: actions/checkout@v4
+    - name: Install Rust
+      run: rustup default ${{ matrix.rust}}
     - name: Build
       run: cargo build --verbose
     - name: Test
@@ -21,6 +22,7 @@ jobs:
     - name: Test --no-default-features
       run: cargo test --no-default-features --verbose
     - name: Test --all-features
+      if: ${{ matrix.rust == 'nightly' }}
       run: cargo test --all-features --verbose
 
   miri:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ rust-version = "1.76"
 std = []
 default = ["serde", "stable_deref_trait", "std"]
 
+unstable_dropck_eyepatch = []
+
 [package.metadata.docs.rs]
 all-features = true
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 
 #![allow(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(feature = "unstable_dropck_eyepatch", feature(dropck_eyepatch))]
 
 extern crate alloc;
 #[cfg(feature = "std")]


### PR DESCRIPTION
This adds a feature to enable the unstable `dropck_eyepatch` feature and use `may_dangle` on `Arc::drop`, which promises we do not access the inner `T` value (as it may have already been dropped) for users to have more linenant borrow checking behaviour around dropping.

`std::sync::Arc` has this attribute, so lacking this blocks migrating from the `std` Arc to `triomphe`.