### PR TITLE
Make the actual read happen in UB tests

### DIFF
--- a/src/arc.rs
+++ b/src/arc.rs
@@ -893,7 +893,7 @@ mod tests {
         uninit.write(String::from("nonononono"));
 
         // Read invalidated reference to trigger UB
-        let _ = *x;
+        let _read = &*x;
     }
 
     #[test]
@@ -909,7 +909,7 @@ mod tests {
         uninit.as_mut_slice()[0].write(String::from("nonononono"));
 
         // Read invalidated reference to trigger UB
-        let _ = *x;
+        let _read = &*x;
     }
 
     #[test]


### PR DESCRIPTION
`let _ = ...`  is a wildcard binding and as such may not perform a read (I'm not 100% sure on the internal semantics here, but using an actual binding avoids the question)