### PR TITLE
Add `Arc::into_unique` for converting back to `UniqueArc`.

### DIFF
--- a/src/arc.rs
+++ b/src/arc.rs
@@ -146,6 +146,56 @@ impl<T> Arc<T> {
     pub fn try_unwrap(this: Self) -> Result<T, Self> {
         Self::try_unique(this).map(UniqueArc::into_inner)
     }
+
+    /// Converts the `Arc` to `UniqueArc` if the `Arc` has exactly one strong reference.
+    ///
+    /// Otherwise, `None` is returned and the `Arc` is dropped.
+    ///
+    /// If `Arc::into_unique` is called on every clone of this `Arc`, it is guaranteed that exactly one of the calls
+    /// returns a `UniqueArc`. This means in particular that the inner data is not dropped.
+    ///
+    /// `Arc::try_unique` is conceptually similar to `Arc::into_unique`, but it is meant for different use-cases. If
+    /// used as a direct replacement for `Arc::into_unique` anyway, such as with the expression
+    /// `Arc::try_unique(this).ok(), then it does not give the same guarantee as described in the previous paragraph.
+    /// For more information, see the examples below and read the documentation of `Arc::try_unique`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use triomphe::Arc;
+    ///
+    /// let x = Arc::new(3);
+    /// let y = Arc::clone(&x);
+    ///
+    /// // Two threads calling `Arc::into_inner` on both clones of an `Arc`:
+    /// let x_thread = std::thread::spawn(|| Arc::into_unique(x));
+    /// let y_thread = std::thread::spawn(|| Arc::into_unique(y));
+    ///
+    /// let x_unique = x_thread.join().unwrap();
+    /// let y_unique = y_thread.join().unwrap();
+    ///
+    /// // One of the threads is guaranteed to receive the inner value:
+    /// assert!((x_unique.is_some() && y_unique.is_none()) || (x_unique.is_none() && y_unique.is_some()));
+    /// // The result could also be `(None, None)` if the threads called
+    /// // `Arc::try_unique(x).ok()` and `Arc::try_unique(y).ok()` instead.
+    /// ```
+    pub fn into_unique(this: Self) -> Option<UniqueArc<T>> {
+        // Ensure that the normal `Drop` implementation is called.
+        let this = ManuallyDrop::new(this);
+
+        // Perform the same logic as `drop_inner` to ensure that the reference count is decremented.
+        if this.inner().count.fetch_sub(1, Release) != 1 {
+            return None;
+        }
+
+        // We're the last holder of this `Arc`, so we can safely turn this into a `UniqueArc`, but we need to first
+        // set the reference count back up to 1.
+        this.inner().count.store(1, Release);
+
+        // SAFETY: The reference count is 1, so the invariant of `UniqueArc` is upheld, and recovering `Self` from
+        // `ManuallyDrop` is safe as we know we're the only owners at this point.
+        Some(unsafe { UniqueArc::from_arc(ManuallyDrop::into_inner(this)) })
+    }
 }
 
 impl<T> Arc<[T]> {
@@ -1108,6 +1158,23 @@ mod tests {
         let data: *const dyn AnInteger = data as *const _;
         let arc: Arc<dyn AnInteger> = unsafe { Arc::from_raw(data) };
         assert_eq!(19, arc.get_me_an_integer());
+    }
+
+    #[test]
+    fn into_unique() {
+        let arc = Arc::new(42);
+        assert_eq!(1, Arc::count(&arc));
+
+        let arc2 = Arc::clone(&arc);
+
+        assert_eq!(2, Arc::count(&arc));
+
+        let arc2_unique = Arc::into_unique(arc2);
+        assert!(arc2_unique.is_none());
+        assert_eq!(1, Arc::count(&arc));
+
+        let arc_unique = Arc::into_unique(arc).unwrap();
+        assert_eq!(42, *arc_unique);
     }
 
     #[allow(dead_code)]


### PR DESCRIPTION
As stated in the title. This is a spiritual equivalent to `std::sync::Arc::into_inner` where we can let shared `Arc` instances be atomically dropped or converted back to an owning `UniqueArc`.