### PR TITLE
Seprate HeaderSliceWithLength into checked and unchecked variants

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -245,17 +245,64 @@ impl<T> From<Vec<T>> for Arc<[T]> {
     }
 }
 
-pub(crate) type HeaderSliceWithLength<H, T> = HeaderSlice<HeaderWithLength<H>, T>;
+/// A type wrapping `HeaderSlice<HeaderWithLength<H>, T>` that is used internally in `ThinArc`.
+///
+/// # Safety
+///
+/// Safety-usable invariants:
+///
+/// - This is guaranteed to have the same representation as `HeaderSlice<HeaderWithLength<H>, T>` (i.e. `HeaderSliceWithLengthUnchecked`)
+/// - For `T` that is  `[U]` or `str`, the header length (`.length()` is checked to be the slice length)
+#[derive(Debug, Hash, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct HeaderSliceWithLengthChecked<H, T: ?Sized> {
+    // Invariant: if T is [U] or str, then the header's length field must be the slice length
+    // Currently no other DSTs are used with this type amd it has no invariants, but these may be added in the future
+    inner: HeaderSliceWithLengthUnchecked<H, T>,
+}
 
-impl<H: PartialOrd, T: ?Sized + PartialOrd> PartialOrd for HeaderSliceWithLength<H, T> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        (&self.header.header, &self.slice).partial_cmp(&(&other.header.header, &other.slice))
+pub type HeaderSliceWithLengthUnchecked<H, T> = HeaderSlice<HeaderWithLength<H>, T>;
+
+// Backcompat alias for `HeaderSliceWithLengthUnchecked`
+#[deprecated = "Move to HeaderSliceWithLengthUnchecked"]
+pub type HeaderSliceWithLength<H, T> = HeaderSliceWithLengthUnchecked<H, T>;
+
+impl<H, T: ?Sized> HeaderSliceWithLengthChecked<H, T> {
+    pub fn header(&self) -> &H {
+        &self.inner.header.header
+    }
+    pub fn header_mut(&self) -> &mut H {
+        // Safety: only the length is unsafe to mutate
+        &mut self.inner.header.header
+    }
+    pub fn length(&self) -> usize {
+        self.inner.header.length
+    }
+
+    pub fn slice(&self) -> &T {
+        &self.inner.slice
+    }
+    pub fn slice_mut(&mut self) -> &mut T {
+        // Safety: only the length is unsafe to mutate
+        &mut self.inner.slice
+    }
+    pub(crate) fn inner(&self) -> &HeaderSliceWithLengthUnchecked<H, T> {
+        // This is safe in an immutable context
+        &self.inner
     }
 }
 
-impl<H: Ord, T: ?Sized + Ord> Ord for HeaderSliceWithLength<H, T> {
+impl<H: PartialOrd, T: ?Sized + PartialOrd> PartialOrd for HeaderSliceWithLengthChecked<H, T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        (&self.inner.header.header, &self.inner.slice)
+            .partial_cmp(&(&other.inner.header.header, &other.inner.slice))
+    }
+}
+
+impl<H: Ord, T: ?Sized + Ord> Ord for HeaderSliceWithLengthChecked<H, T> {
     fn cmp(&self, other: &Self) -> Ordering {
-        (&self.header.header, &self.slice).cmp(&(&other.header.header, &other.slice))
+        (&self.inner.header.header, &self.inner.slice)
+            .cmp(&(&other.inner.header.header, &other.inner.slice))
     }
 }
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -253,7 +253,7 @@ impl<T> From<Vec<T>> for Arc<[T]> {
 ///
 /// - This is guaranteed to have the same representation as `HeaderSlice<HeaderWithLength<H>, T>` (i.e. `HeaderSliceWithLengthUnchecked`)
 /// - For `T` that is  `[U]` or `str`, the header length (`.length()` is checked to be the slice length)
-#[derive(Debug, Hash, Eq, PartialEq)]
+#[derive(Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 #[repr(transparent)]
 pub struct HeaderSliceWithLengthChecked<H, T: ?Sized> {
     // Invariant: if T is [U] or str, then the header's length field must be the slice length
@@ -267,7 +267,7 @@ impl<H, T: ?Sized> HeaderSliceWithLengthChecked<H, T> {
     pub fn header(&self) -> &H {
         &self.inner.header.header
     }
-    pub fn header_mut(&self) -> &mut H {
+    pub fn header_mut(&mut self) -> &mut H {
         // Safety: only the length is unsafe to mutate
         &mut self.inner.header.header
     }
@@ -288,17 +288,17 @@ impl<H, T: ?Sized> HeaderSliceWithLengthChecked<H, T> {
     }
 }
 
-impl<H: PartialOrd, T: ?Sized + PartialOrd> PartialOrd for HeaderSliceWithLengthChecked<H, T> {
+impl<H: PartialOrd, T: ?Sized + PartialOrd> PartialOrd for HeaderSliceWithLengthUnchecked<H, T> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        (&self.inner.header.header, &self.inner.slice)
-            .partial_cmp(&(&other.inner.header.header, &other.inner.slice))
+        (&self.header.header, &self.slice)
+            .partial_cmp(&(&other.header.header, &other.slice))
     }
 }
 
-impl<H: Ord, T: ?Sized + Ord> Ord for HeaderSliceWithLengthChecked<H, T> {
+impl<H: Ord, T: ?Sized + Ord> Ord for HeaderSliceWithLengthUnchecked<H, T> {
     fn cmp(&self, other: &Self) -> Ordering {
-        (&self.inner.header.header, &self.inner.slice)
-            .cmp(&(&other.inner.header.header, &other.inner.slice))
+        (&self.header.header, &self.slice)
+            .cmp(&(&other.header.header, &other.slice))
     }
 }
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -263,10 +263,6 @@ pub struct HeaderSliceWithLengthChecked<H, T: ?Sized> {
 
 pub type HeaderSliceWithLengthUnchecked<H, T> = HeaderSlice<HeaderWithLength<H>, T>;
 
-// Backcompat alias for `HeaderSliceWithLengthUnchecked`
-#[deprecated = "Move to HeaderSliceWithLengthUnchecked"]
-pub type HeaderSliceWithLength<H, T> = HeaderSliceWithLengthUnchecked<H, T>;
-
 impl<H, T: ?Sized> HeaderSliceWithLengthChecked<H, T> {
     pub fn header(&self) -> &H {
         &self.inner.header.header

--- a/src/header.rs
+++ b/src/header.rs
@@ -255,15 +255,15 @@ impl<T> From<Vec<T>> for Arc<[T]> {
 /// - For `T` that is  `[U]` or `str`, the header length (`.length()` is checked to be the slice length)
 #[derive(Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 #[repr(transparent)]
-pub struct HeaderSliceWithLengthChecked<H, T: ?Sized> {
+pub struct HeaderSliceWithLengthProtected<H, T: ?Sized> {
     // Invariant: if T is [U] or str, then the header's length field must be the slice length
     // Currently no other DSTs are used with this type amd it has no invariants, but these may be added in the future
     inner: HeaderSliceWithLengthUnchecked<H, T>,
 }
 
-pub type HeaderSliceWithLengthUnchecked<H, T> = HeaderSlice<HeaderWithLength<H>, T>;
+pub(crate) type HeaderSliceWithLengthUnchecked<H, T> = HeaderSlice<HeaderWithLength<H>, T>;
 
-impl<H, T: ?Sized> HeaderSliceWithLengthChecked<H, T> {
+impl<H, T: ?Sized> HeaderSliceWithLengthProtected<H, T> {
     pub fn header(&self) -> &H {
         &self.inner.header.header
     }
@@ -290,15 +290,13 @@ impl<H, T: ?Sized> HeaderSliceWithLengthChecked<H, T> {
 
 impl<H: PartialOrd, T: ?Sized + PartialOrd> PartialOrd for HeaderSliceWithLengthUnchecked<H, T> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        (&self.header.header, &self.slice)
-            .partial_cmp(&(&other.header.header, &other.slice))
+        (&self.header.header, &self.slice).partial_cmp(&(&other.header.header, &other.slice))
     }
 }
 
 impl<H: Ord, T: ?Sized + Ord> Ord for HeaderSliceWithLengthUnchecked<H, T> {
     fn cmp(&self, other: &Self) -> Ordering {
-        (&self.header.header, &self.slice)
-            .cmp(&(&other.header.header, &other.slice))
+        (&self.header.header, &self.slice).cmp(&(&other.header.header, &other.slice))
     }
 }
 

--- a/src/thin_arc.rs
+++ b/src/thin_arc.rs
@@ -107,7 +107,11 @@ impl<H, T> ThinArc<H, T> {
 
         // Expose the transient Arc to the callback, which may clone it if it wants
         // and forward the result to the user
-        f(&mut transient)
+        let ret = f(&mut transient);
+        // It is possible for the user to replace the Arc entirely here. If so, we need to update the ThinArc as well
+        // Safety: We're still in the realm of Protected types so this cast is safe
+        self.ptr = transient.p.cast();
+        ret
     }
 
     /// Creates a `ThinArc` for a HeaderSlice using the given header struct and

--- a/src/thin_arc.rs
+++ b/src/thin_arc.rs
@@ -237,9 +237,6 @@ impl<H, T> Arc<HeaderSliceWithLengthUnchecked<H, [T]>> {
 
     /// Converts an `Arc` into a `ThinArc`. This consumes the `Arc`, so the refcount
     /// is not modified.
-    ///
-    /// # Safety
-    /// Assumes that the header length matches the slice length.
     #[inline]
     fn from_checked_header(a: Arc<HeaderSliceWithLengthChecked<H, [T]>>) -> Self {
         // Safety: HeaderSliceWithLengthChecked and HeaderSliceWithLengthUnchecked have the same layout

--- a/src/unique_arc.rs
+++ b/src/unique_arc.rs
@@ -299,7 +299,7 @@ impl<T: Serialize> Serialize for UniqueArc<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Arc, HeaderSliceWithLength, HeaderWithLength, UniqueArc};
+    use crate::{Arc, HeaderSliceWithLengthUnchecked, HeaderWithLength, UniqueArc};
     use core::{convert::TryFrom, mem::MaybeUninit};
 
     #[test]
@@ -332,7 +332,7 @@ mod tests {
 
     #[test]
     fn from_header_and_uninit_slice() {
-        let mut uarc: UniqueArc<HeaderSliceWithLength<u8, [MaybeUninit<u16>]>> =
+        let mut uarc: UniqueArc<HeaderSliceWithLengthUnchecked<u8, [MaybeUninit<u16>]>> =
             UniqueArc::from_header_and_uninit_slice(HeaderWithLength::new(1, 3), 3);
         uarc.slice.fill(MaybeUninit::new(2));
         let arc = unsafe { uarc.assume_init_slice_with_header() }.shareable();


### PR DESCRIPTION
Fixes #107


The breakage is limited to `with_mut()`, which now returns a `HeaderSliceWithLengthChecked` which has an immutable header.

Not fully happy with the resultant API, worth cleaning up in the next major release.