### PR TITLE
Make `HeaderSliceWithLen…` always contain slices

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -251,19 +251,19 @@ impl<T> From<Vec<T>> for Arc<[T]> {
 ///
 /// Safety-usable invariants:
 ///
-/// - This is guaranteed to have the same representation as `HeaderSlice<HeaderWithLength<H>, T>` (i.e. `HeaderSliceWithLengthUnchecked`)
-/// - For `T` that is  `[U]` or `str`, the header length (`.length()` is checked to be the slice length)
+/// - This is guaranteed to have the same representation as `HeaderSlice<HeaderWithLength<H>, [T]>`
+/// - The header length (`.length()`) is checked to be the slice length
 #[derive(Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 #[repr(transparent)]
-pub struct HeaderSliceWithLengthProtected<H, T: ?Sized> {
+pub struct HeaderSliceWithLengthProtected<H, T> {
     // Invariant: if T is [U] or str, then the header's length field must be the slice length
     // Currently no other DSTs are used with this type amd it has no invariants, but these may be added in the future
     inner: HeaderSliceWithLengthUnchecked<H, T>,
 }
 
-pub(crate) type HeaderSliceWithLengthUnchecked<H, T> = HeaderSlice<HeaderWithLength<H>, T>;
+pub(crate) type HeaderSliceWithLengthUnchecked<H, T> = HeaderSlice<HeaderWithLength<H>, [T]>;
 
-impl<H, T: ?Sized> HeaderSliceWithLengthProtected<H, T> {
+impl<H, T> HeaderSliceWithLengthProtected<H, T> {
     pub fn header(&self) -> &H {
         &self.inner.header.header
     }
@@ -275,10 +275,10 @@ impl<H, T: ?Sized> HeaderSliceWithLengthProtected<H, T> {
         self.inner.header.length
     }
 
-    pub fn slice(&self) -> &T {
+    pub fn slice(&self) -> &[T] {
         &self.inner.slice
     }
-    pub fn slice_mut(&mut self) -> &mut T {
+    pub fn slice_mut(&mut self) -> &mut [T] {
         // Safety: only the length is unsafe to mutate
         &mut self.inner.slice
     }
@@ -288,13 +288,13 @@ impl<H, T: ?Sized> HeaderSliceWithLengthProtected<H, T> {
     }
 }
 
-impl<H: PartialOrd, T: ?Sized + PartialOrd> PartialOrd for HeaderSliceWithLengthUnchecked<H, T> {
+impl<H: PartialOrd, T: ?Sized + PartialOrd> PartialOrd for HeaderSlice<HeaderWithLength<H>, T> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         (&self.header.header, &self.slice).partial_cmp(&(&other.header.header, &other.slice))
     }
 }
 
-impl<H: Ord, T: ?Sized + Ord> Ord for HeaderSliceWithLengthUnchecked<H, T> {
+impl<H: Ord, T: ?Sized + Ord> Ord for HeaderSlice<HeaderWithLength<H>, T> {
     fn cmp(&self, other: &Self) -> Ordering {
         (&self.header.header, &self.slice).cmp(&(&other.header.header, &other.slice))
     }

--- a/src/thin_arc.rs
+++ b/src/thin_arc.rs
@@ -157,7 +157,7 @@ impl<H, T> ThinArc<H, T> {
     /// within it -- for memory reporting.
     #[inline]
     pub fn ptr(&self) -> *const c_void {
-        self.ptr.as_ptr() as *const ArcInner<T> as *const c_void
+        self.ptr.cast().as_ptr()
     }
 
     /// Returns the address on the heap of the Arc itself -- not the T within it -- for memory
@@ -190,7 +190,7 @@ impl<H, T> ThinArc<H, T> {
     #[inline]
     pub fn into_raw(self) -> *const c_void {
         let this = ManuallyDrop::new(self);
-        this.ptr.cast().as_ptr()
+        this.ptr()
     }
 
     /// Provides a raw pointer to the data.

--- a/src/unique_arc.rs
+++ b/src/unique_arc.rs
@@ -332,7 +332,7 @@ mod tests {
 
     #[test]
     fn from_header_and_uninit_slice() {
-        let mut uarc: UniqueArc<HeaderSliceWithLengthUnchecked<u8, [MaybeUninit<u16>]>> =
+        let mut uarc: UniqueArc<HeaderSliceWithLengthUnchecked<u8, MaybeUninit<u16>>> =
             UniqueArc::from_header_and_uninit_slice(HeaderWithLength::new(1, 3), 3);
         uarc.slice.fill(MaybeUninit::new(2));
         let arc = unsafe { uarc.assume_init_slice_with_header() }.shareable();


### PR DESCRIPTION
This also changes the `ptr:` field of `ThinArc` back to be a non-`…Protected` type. And that's good, because it used `[T; 0]` so the invariantes used to be deliberately broken.
```rust
ptr: ptr::NonNull<ArcInner<HeaderSlice<HeaderWithLength<H>, [T; 0]>>>
```
After this, I also looked through all uses of `ptr` and reworked a few of them (for instance, many of them directly passed the pointer to `thin_to_thick`; which is now part of `thin_to_thick` itself.

This PR currently targets the PR branch of #108 directly, so feel free to fast-forward merge if it should become part of #108, or let me re-target `master` if this should become a follow-up PR.