### PR TITLE
Change the acq load to explict acq fence for #113

### DIFF
--- a/src/arc.rs
+++ b/src/arc.rs
@@ -651,7 +651,7 @@ impl<T: ?Sized> Arc<T> {
         //
         // [1]: (www.boost.org/doc/libs/1_55_0/doc/html/atomic/usage_examples.html)
         // [2]: https://github.com/rust-lang/rust/pull/41714
-        self.inner().count.load(Acquire);
+        atomic::fence(Acquire);
 
         unsafe {
             self.drop_slow();


### PR DESCRIPTION
As discussed in #113 , we want to change the `load acq` to explict `fence acq` to guarantee the memory fence.
This behavior also matches to the std in Rust.

For details, please check:

1. https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4455.html
2. https://github.com/rust-lang/rust/pull/41714