### PR TITLE
Unpin nightly toolchain used for threadsan CI job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,11 +58,7 @@ jobs:
     - name: Install latest nightly
       uses: actions-rs/toolchain@v1
       with:
-          # FIXME: Due to https://github.com/rust-lang/rust/issues/146465, more recent Nightly versions
-          # are unable to build the doctests. Since we only need Nightly to use -Zbuild-std, it's fine
-          # to just pin the last working version. Once that issue is fixed, we can use more recent
-          # versions again.
-          toolchain: nightly-2025-09-05
+          toolchain: nightly
           override: true
           profile: minimal
           components: rust-src


### PR DESCRIPTION
We can undo this now that https://github.com/rust-lang/rust/pull/148068 is merged.