### PR TITLE
feat: make Arc/ThinArc/UniqueArc APIs const-compatible, bump MSRV to 1.85

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,88 +9,86 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.81
+          - 1.85
           - nightly
     steps:
-    - uses: actions/checkout@v4
-    - name: Install Rust
-      run: rustup default ${{ matrix.rust }}
-    - name: Build
-      run: cargo build --verbose
-    - name: Test
-      run: cargo test
-    - name: Test --no-default-features
-      run: cargo test --no-default-features --verbose
-    - name: Test --all-features
-      if: ${{ matrix.rust == 'nightly' }}
-      run: cargo test --all-features --verbose
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: rustup default ${{ matrix.rust }}
+      - name: Build
+        run: cargo build --verbose
+      - name: Test
+        run: cargo test
+      - name: Test --no-default-features
+        run: cargo test --no-default-features --verbose
+      - name: Test --all-features
+        if: ${{ matrix.rust == 'nightly' }}
+        run: cargo test --all-features --verbose
 
   miri:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Install Rust Nightly
-      uses: actions-rs/toolchain@v1
-      with:
+      - uses: actions/checkout@v4
+      - name: Install Rust Nightly
+        uses: actions-rs/toolchain@v1
+        with:
           toolchain: nightly
           profile: minimal
           components: miri
-    - name: Miri Test
-      run: cargo +nightly miri test
-    - name: Test --no-default-features
-      run: cargo +nightly miri test --no-default-features
-    - name: Test --all-features
-      run: cargo +nightly miri test --all-features
+      - name: Miri Test
+        run: cargo +nightly miri test
+      - name: Test --no-default-features
+        run: cargo +nightly miri test --no-default-features
+      - name: Test --all-features
+        run: cargo +nightly miri test --all-features
 
   thread_sanitizer:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ github.event.repository.name }}-${{ runner.os }}-cargo-thread_sanitizer-v2
-    - name: Install latest nightly
-      uses: actions-rs/toolchain@v1
-      with:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ github.event.repository.name }}-${{ runner.os }}-cargo-thread_sanitizer-v2
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
           toolchain: nightly
           override: true
           profile: minimal
           components: rust-src
-    - name: Run thread sanitizer
-      env:
-        RUSTDOCFLAGS: -Zsanitizer=thread
-        RUSTFLAGS: -Zsanitizer=thread
-      run:
-        for _ in $(seq 1 10); do cargo test -Zbuild-std --target $(uname -m)-unknown-linux-gnu; done
+      - name: Run thread sanitizer
+        env:
+          RUSTDOCFLAGS: -Zsanitizer=thread
+          RUSTFLAGS: -Zsanitizer=thread
+        run: for _ in $(seq 1 10); do cargo test -Zbuild-std --target $(uname -m)-unknown-linux-gnu; done
 
   address_sanitizer:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ github.event.repository.name }}-${{ runner.os }}-cargo-address_sanitizer-v2
-    - name: Install latest nightly
-      uses: actions-rs/toolchain@v1
-      with:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ github.event.repository.name }}-${{ runner.os }}-cargo-address_sanitizer-v2
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
           toolchain: nightly
           override: true
           profile: minimal
-    - name: Run address sanitizer
-      env:
-        RUSTDOCFLAGS: -Zsanitizer=address
-        RUSTFLAGS: -Zsanitizer=address
-      run:
-        for _ in $(seq 1 10); do cargo test; done
+      - name: Run address sanitizer
+        env:
+          RUSTDOCFLAGS: -Zsanitizer=address
+          RUSTFLAGS: -Zsanitizer=address
+        run: for _ in $(seq 1 10); do cargo test; done

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["arc", "ffi", "sync", "data-structure"]
 categories = ["concurrency", "data-structures"]
 
 # MSRV policy: May be updated in minor versions
-rust-version = "1.81"
+rust-version = "1.85"
 edition = "2021"
 
 [features]

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -1,7 +1,6 @@
 use alloc::alloc::handle_alloc_error;
 use alloc::boxed::Box;
 use core::alloc::Layout;
-use core::borrow;
 use core::cmp::Ordering;
 use core::convert::From;
 use core::ffi::c_void;
@@ -15,6 +14,7 @@ use core::panic::{RefUnwindSafe, UnwindSafe};
 use core::ptr::{self, addr_of_mut, NonNull};
 use core::sync::atomic;
 use core::sync::atomic::Ordering::{AcqRel, Acquire, Relaxed, Release};
+use core::{borrow, mem};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "stable_deref_trait")]
@@ -48,12 +48,14 @@ impl<T: ?Sized> ArcInner<T> {
     ///   That happens automatically if the pointer comes from `Arc` and type was not changed.
     ///   This is **not** the case, for example, when `Arc` was uninitialized `MaybeUninit<T>`
     ///   and the pointer was cast to `*const T`.
-    unsafe fn offset_of_data(value: *const T) -> usize {
+    const unsafe fn offset_of_data(value: *const T) -> usize {
         // We can use `Layout::for_value_raw` when it is stable.
         let value = &*value;
 
         let layout = Layout::new::<atomic::AtomicUsize>();
-        let (_, offset) = layout.extend(Layout::for_value(value)).unwrap();
+        let Ok((_, offset)) = layout.extend(Layout::for_value(value)) else {
+            panic!("failed to extend")
+        };
         offset
     }
 }
@@ -241,9 +243,10 @@ impl<T: ?Sized> Arc<T> {
     ///
     /// It is recommended to use OffsetArc for this.
     #[inline]
-    pub fn into_raw(this: Self) -> *const T {
-        let this = ManuallyDrop::new(this);
-        this.as_ptr()
+    pub const fn into_raw(this: Self) -> *const T {
+        let ret = this.as_ptr();
+        mem::forget(this);
+        ret
     }
 
     /// Reconstruct the `Arc<T>` from a raw pointer obtained from into_raw()
@@ -257,7 +260,7 @@ impl<T: ?Sized> Arc<T> {
     /// - The given pointer must be a valid pointer to `T` that came from [`Arc::into_raw`].
     /// - After `from_raw`, the pointer must not be accessed.
     #[inline]
-    pub unsafe fn from_raw(ptr: *const T) -> Self {
+    pub const unsafe fn from_raw(ptr: *const T) -> Self {
         // To find the corresponding pointer to the `ArcInner` we need
         // to subtract the offset of the `data` field from the pointer.
 
@@ -297,7 +300,7 @@ impl<T: ?Sized> Arc<T> {
     ///
     /// Same as into_raw except `self` isn't consumed.
     #[inline]
-    pub fn as_ptr(&self) -> *const T {
+    pub const fn as_ptr(&self) -> *const T {
         // SAFETY: This cannot go through a reference to `data`, because this method
         // is used to implement `into_raw`. To reconstruct the full `Arc` from this
         // pointer, it needs to maintain its full provenance, and not be reduced to
@@ -310,13 +313,13 @@ impl<T: ?Sized> Arc<T> {
     /// It has the benefits of an `&T` but also knows about the underlying refcount
     /// and can be converted into more `Arc<T>`s if necessary.
     #[inline]
-    pub fn borrow_arc(&self) -> ArcBorrow<'_, T> {
+    pub const fn borrow_arc(&self) -> ArcBorrow<'_, T> {
         unsafe { ArcBorrow(NonNull::new_unchecked(self.as_ptr() as *mut T), PhantomData) }
     }
 
     /// Returns the address on the heap of the Arc itself -- not the T within it -- for memory
     /// reporting.
-    pub fn heap_ptr(&self) -> *const c_void {
+    pub const fn heap_ptr(&self) -> *const c_void {
         self.p.as_ptr() as *const ArcInner<T> as *const c_void
     }
 
@@ -334,16 +337,17 @@ impl<T: ?Sized> Arc<T> {
     }
 
     #[inline]
-    pub(super) fn into_raw_inner(this: Self) -> *mut ArcInner<T> {
-        let this = ManuallyDrop::new(this);
-        this.ptr()
+    pub(super) const fn into_raw_inner(this: Self) -> *mut ArcInner<T> {
+        let ret = this.ptr();
+        mem::forget(this);
+        ret
     }
 
     /// Construct an `Arc` from an allocated `ArcInner`.
     /// # Safety
     /// The `ptr` must point to a valid instance, allocated by an `Arc`. The reference could will
     /// not be modified.
-    pub(super) unsafe fn from_raw_inner(ptr: *mut ArcInner<T>) -> Self {
+    pub(super) const unsafe fn from_raw_inner(ptr: *mut ArcInner<T>) -> Self {
         Arc {
             p: ptr::NonNull::new_unchecked(ptr),
             phantom: PhantomData,
@@ -351,7 +355,7 @@ impl<T: ?Sized> Arc<T> {
     }
 
     #[inline]
-    pub(super) fn inner(&self) -> &ArcInner<T> {
+    pub(super) const fn inner(&self) -> &ArcInner<T> {
         // This unsafety is ok because while this arc is alive we're guaranteed
         // that the inner pointer is valid. Furthermore, we know that the
         // `ArcInner` structure itself is `Sync` because the inner data is
@@ -373,7 +377,7 @@ impl<T: ?Sized> Arc<T> {
         ptr::addr_eq(this.ptr(), other.ptr())
     }
 
-    pub(crate) fn ptr(&self) -> *mut ArcInner<T> {
+    pub(crate) const fn ptr(&self) -> *mut ArcInner<T> {
         self.p.as_ptr()
     }
 
@@ -562,7 +566,7 @@ impl<T> Arc<MaybeUninit<T>> {
 
     /// Obtain a mutable pointer to the stored `MaybeUninit<T>`.
     #[inline]
-    pub fn as_mut_ptr(&mut self) -> *mut MaybeUninit<T> {
+    pub const fn as_mut_ptr(&mut self) -> *mut MaybeUninit<T> {
         unsafe { core::ptr::addr_of_mut!((*self.ptr()).data) }
     }
 
@@ -570,8 +574,10 @@ impl<T> Arc<MaybeUninit<T>> {
     ///
     /// Must initialize all fields before calling this function.
     #[inline]
-    pub unsafe fn assume_init(self) -> Arc<T> {
-        Arc::from_raw_inner(ManuallyDrop::new(self).ptr().cast())
+    pub const unsafe fn assume_init(self) -> Arc<T> {
+        let ptr = self.ptr();
+        mem::forget(self);
+        Arc::from_raw_inner(ptr.cast())
     }
 }
 
@@ -602,8 +608,10 @@ impl<T> Arc<[MaybeUninit<T>]> {
     ///
     /// Must initialize all fields before calling this function.
     #[inline]
-    pub unsafe fn assume_init(self) -> Arc<[T]> {
-        Arc::from_raw_inner(ManuallyDrop::new(self).ptr() as _)
+    pub const unsafe fn assume_init(self) -> Arc<[T]> {
+        let ptr = self.ptr();
+        mem::forget(self);
+        Arc::from_raw_inner(ptr as _)
     }
 }
 

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -231,7 +231,7 @@ impl<T> Arc<[T]> {
     ///  # Safety
     /// - The given pointer must be a valid pointer to `[T]` that came from [`Arc::into_raw`].
     /// - After `from_raw_slice`, the pointer must not be accessed.
-    pub unsafe fn from_raw_slice(ptr: *const [T]) -> Self {
+    pub const unsafe fn from_raw_slice(ptr: *const [T]) -> Self {
         Arc::from_raw(ptr)
     }
 }
@@ -278,16 +278,16 @@ impl<T: ?Sized> Arc<T> {
     /// Converts a `OffsetArc` into an `Arc`. This consumes the `OffsetArc`, so the refcount
     /// is not modified.
     #[inline]
-    pub fn from_raw_offset(a: OffsetArc<T>) -> Self {
-        let a = ManuallyDrop::new(a);
+    pub const fn from_raw_offset(a: OffsetArc<T>) -> Self {
         let ptr = a.ptr.as_ptr();
+        mem::forget(a);
         unsafe { Arc::from_raw(ptr) }
     }
 
     /// Converts an `Arc` into a `OffsetArc`. This consumes the `Arc`, so the refcount
     /// is not modified.
     #[inline]
-    pub fn into_raw_offset(a: Self) -> OffsetArc<T> {
+    pub const fn into_raw_offset(a: Self) -> OffsetArc<T> {
         unsafe {
             OffsetArc {
                 ptr: ptr::NonNull::new_unchecked(Arc::into_raw(a) as *mut T),

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -1,6 +1,7 @@
 use alloc::alloc::handle_alloc_error;
 use alloc::boxed::Box;
 use core::alloc::Layout;
+use core::borrow;
 use core::cmp::Ordering;
 use core::convert::From;
 use core::ffi::c_void;
@@ -14,13 +15,12 @@ use core::panic::{RefUnwindSafe, UnwindSafe};
 use core::ptr::{self, addr_of_mut, NonNull};
 use core::sync::atomic;
 use core::sync::atomic::Ordering::{AcqRel, Acquire, Relaxed, Release};
-use core::{borrow, mem};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "stable_deref_trait")]
 use stable_deref_trait::{CloneStableDeref, StableDeref};
 
-use crate::{abort, AllocError, ArcBorrow, HeaderSlice, OffsetArc, UniqueArc};
+use crate::{abort, mdref, AllocError, ArcBorrow, HeaderSlice, OffsetArc, UniqueArc};
 
 /// A soft limit on the amount of references that may be made to an `Arc`.
 ///
@@ -244,9 +244,8 @@ impl<T: ?Sized> Arc<T> {
     /// It is recommended to use OffsetArc for this.
     #[inline]
     pub const fn into_raw(this: Self) -> *const T {
-        let ret = this.as_ptr();
-        mem::forget(this);
-        ret
+        let this = ManuallyDrop::new(this);
+        mdref(&this).as_ptr()
     }
 
     /// Reconstruct the `Arc<T>` from a raw pointer obtained from into_raw()
@@ -279,8 +278,8 @@ impl<T: ?Sized> Arc<T> {
     /// is not modified.
     #[inline]
     pub const fn from_raw_offset(a: OffsetArc<T>) -> Self {
-        let ptr = a.ptr.as_ptr();
-        mem::forget(a);
+        let a = ManuallyDrop::new(a);
+        let ptr = mdref(&a).ptr.as_ptr();
         unsafe { Arc::from_raw(ptr) }
     }
 
@@ -338,9 +337,8 @@ impl<T: ?Sized> Arc<T> {
 
     #[inline]
     pub(super) const fn into_raw_inner(this: Self) -> *mut ArcInner<T> {
-        let ret = this.ptr();
-        mem::forget(this);
-        ret
+        let this = ManuallyDrop::new(this);
+        mdref(&this).ptr()
     }
 
     /// Construct an `Arc` from an allocated `ArcInner`.
@@ -575,9 +573,8 @@ impl<T> Arc<MaybeUninit<T>> {
     /// Must initialize all fields before calling this function.
     #[inline]
     pub const unsafe fn assume_init(self) -> Arc<T> {
-        let ptr = self.ptr();
-        mem::forget(self);
-        Arc::from_raw_inner(ptr.cast())
+        let this = ManuallyDrop::new(self);
+        Arc::from_raw_inner(mdref(&this).ptr().cast())
     }
 }
 
@@ -609,9 +606,8 @@ impl<T> Arc<[MaybeUninit<T>]> {
     /// Must initialize all fields before calling this function.
     #[inline]
     pub const unsafe fn assume_init(self) -> Arc<[T]> {
-        let ptr = self.ptr();
-        mem::forget(self);
-        Arc::from_raw_inner(ptr as _)
+        let this = ManuallyDrop::new(self);
+        Arc::from_raw_inner(mdref(&this).ptr() as _)
     }
 }
 

--- a/src/arc_borrow.rs
+++ b/src/arc_borrow.rs
@@ -63,7 +63,7 @@ impl<'a, T> ArcBorrow<'a, T> {
     ///   of the 3 types, only Trimphe's `Arc` offers a direct API for obtaining such a pointer:
     ///   [`Arc::as_ptr`].
     #[inline]
-    pub unsafe fn from_ptr(ptr: *const T) -> Self {
+    pub const unsafe fn from_ptr(ptr: *const T) -> Self {
         unsafe { ArcBorrow(NonNull::new_unchecked(ptr as *mut T), PhantomData) }
     }
 
@@ -105,7 +105,7 @@ impl<'a, T> ArcBorrow<'a, T> {
     /// Similar to deref, but uses the lifetime |a| rather than the lifetime of
     /// self, which is incompatible with the signature of the Deref trait.
     #[inline]
-    pub fn get(&self) -> &'a T {
+    pub const fn get(&self) -> &'a T {
         unsafe { &*self.0.as_ptr() }
     }
 }

--- a/src/arc_union.rs
+++ b/src/arc_union.rs
@@ -44,7 +44,7 @@ pub enum ArcUnionBorrow<'a, A: 'a, B: 'a> {
 }
 
 impl<A, B> ArcUnion<A, B> {
-    unsafe fn new(ptr: *mut ()) -> Self {
+    const unsafe fn new(ptr: *mut ()) -> Self {
         ArcUnion {
             p: ptr::NonNull::new_unchecked(ptr),
             phantom_a: PhantomData,
@@ -79,7 +79,7 @@ impl<A, B> ArcUnion<A, B> {
 
     /// Creates an `ArcUnion` from an instance of the first type.
     #[inline]
-    pub fn from_first(other: Arc<A>) -> Self {
+    pub const fn from_first(other: Arc<A>) -> Self {
         unsafe { Self::new(Arc::into_raw(other) as *mut _) }
     }
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -295,7 +295,7 @@ pub struct HeaderWithLength<H> {
 impl<H> HeaderWithLength<H> {
     /// Creates a new HeaderWithLength.
     #[inline]
-    pub fn new(header: H, length: usize) -> Self {
+    pub const fn new(header: H, length: usize) -> Self {
         HeaderWithLength { header, length }
     }
 }
@@ -410,25 +410,25 @@ pub struct HeaderSliceWithLengthProtected<H, T> {
 pub(crate) type HeaderSliceWithLengthUnchecked<H, T> = HeaderSlice<HeaderWithLength<H>, [T]>;
 
 impl<H, T> HeaderSliceWithLengthProtected<H, T> {
-    pub fn header(&self) -> &H {
+    pub const fn header(&self) -> &H {
         &self.inner.header.header
     }
-    pub fn header_mut(&mut self) -> &mut H {
+    pub const fn header_mut(&mut self) -> &mut H {
         // Safety: only the length is unsafe to mutate
         &mut self.inner.header.header
     }
-    pub fn length(&self) -> usize {
+    pub const fn length(&self) -> usize {
         self.inner.header.length
     }
 
-    pub fn slice(&self) -> &[T] {
+    pub const fn slice(&self) -> &[T] {
         &self.inner.slice
     }
-    pub fn slice_mut(&mut self) -> &mut [T] {
+    pub const fn slice_mut(&mut self) -> &mut [T] {
         // Safety: only the length is unsafe to mutate
         &mut self.inner.slice
     }
-    pub(crate) fn inner(&self) -> &HeaderSliceWithLengthUnchecked<H, T> {
+    pub(crate) const fn inner(&self) -> &HeaderSliceWithLengthUnchecked<H, T> {
         // This is safe in an immutable context
         &self.inner
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,10 @@ fn abort() -> ! {
     panic!();
 }
 
+// `ManuallyDrop::deref` is a `Deref` trait method, so it isn't callable in a
+// `const fn` on our MSRV. This is a const-compatible substitute.
 const fn mdref<T>(v: &core::mem::ManuallyDrop<T>) -> &T {
+    // SAFETY: `ManuallyDrop<T>` is `repr(transparent)` over `T`, so `&ManuallyDrop<T>`
+    // and `&T` have identical layout and this reference cast is sound.
     unsafe { core::mem::transmute(v) }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,3 +72,7 @@ fn abort() -> ! {
     let _double_panicer = PanicOnDrop;
     panic!();
 }
+
+const fn mdref<T>(v: &core::mem::ManuallyDrop<T>) -> &T {
+    unsafe { core::mem::transmute(v) }
+}

--- a/src/offset_arc.rs
+++ b/src/offset_arc.rs
@@ -158,7 +158,7 @@ impl<T: ?Sized> OffsetArc<T> {
     /// Produce a pointer to the data that can be converted back
     /// to an `Arc`
     #[inline]
-    pub fn borrow_arc(&self) -> ArcBorrow<'_, T> {
+    pub const fn borrow_arc(&self) -> ArcBorrow<'_, T> {
         ArcBorrow(self.ptr, PhantomData)
     }
 

--- a/src/thin_arc.rs
+++ b/src/thin_arc.rs
@@ -336,10 +336,9 @@ impl<H, T> Arc<HeaderSliceWithLengthProtected<H, T>> {
     /// Converts an `Arc` into a `ThinArc`. This consumes the `Arc`, so the refcount
     /// is not modified.
     #[inline]
-    pub fn protected_into_thin(a: Self) -> ThinArc<H, T> {
-        debug_assert_eq!(
-            a.length(),
-            a.slice().len(),
+    pub const fn protected_into_thin(a: Self) -> ThinArc<H, T> {
+        debug_assert!(
+            a.inner().data.length() == a.inner().data.slice().len(),
             "Length needs to be correct for ThinArc to work"
         );
 

--- a/src/thin_arc.rs
+++ b/src/thin_arc.rs
@@ -1,6 +1,5 @@
 use core::cmp::Ordering;
 use core::ffi::c_void;
-use core::fmt;
 use core::hash::{Hash, Hasher};
 use core::iter::{ExactSizeIterator, Iterator};
 use core::marker::PhantomData;
@@ -8,6 +7,7 @@ use core::mem::ManuallyDrop;
 use core::ops::Deref;
 use core::panic::{RefUnwindSafe, UnwindSafe};
 use core::ptr;
+use core::{fmt, mem};
 
 use super::{Arc, ArcInner, HeaderSlice, HeaderSliceWithLengthProtected, HeaderWithLength};
 use crate::header::HeaderSliceWithLengthUnchecked;
@@ -55,7 +55,9 @@ impl<H: RefUnwindSafe, T: RefUnwindSafe> UnwindSafe for ThinArc<H, T> {}
 //
 // See the comment around the analogous operation in from_header_and_iter.
 #[inline]
-fn thin_to_thick<H, T>(arc: &ThinArc<H, T>) -> *mut ArcInner<HeaderSliceWithLengthProtected<H, T>> {
+const fn thin_to_thick<H, T>(
+    arc: &ThinArc<H, T>,
+) -> *mut ArcInner<HeaderSliceWithLengthProtected<H, T>> {
     let thin = arc.ptr.as_ptr();
     let len = unsafe { (*thin).data.header.length };
     let fake_slice = ptr::slice_from_raw_parts_mut(thin as *mut T, len);
@@ -198,14 +200,14 @@ impl<H, T> ThinArc<H, T> {
     /// Returns the address on the heap of the ThinArc itself -- not the T
     /// within it -- for memory reporting.
     #[inline]
-    pub fn ptr(&self) -> *const c_void {
+    pub const fn ptr(&self) -> *const c_void {
         self.ptr.cast().as_ptr()
     }
 
     /// Returns the address on the heap of the Arc itself -- not the T within it -- for memory
     /// reporting.
     #[inline]
-    pub fn heap_ptr(&self) -> *const c_void {
+    pub const fn heap_ptr(&self) -> *const c_void {
         self.ptr()
     }
 
@@ -221,7 +223,7 @@ impl<H, T> ThinArc<H, T> {
     /// This function is unsafe because improper use may lead to memory unsafety,
     /// even if the returned ThinArc is never accessed.
     #[inline]
-    pub unsafe fn from_raw(ptr: *const c_void) -> Self {
+    pub const unsafe fn from_raw(ptr: *const c_void) -> Self {
         Self {
             ptr: ptr::NonNull::new_unchecked(ptr as *mut c_void).cast(),
             phantom: PhantomData,
@@ -230,16 +232,17 @@ impl<H, T> ThinArc<H, T> {
 
     /// Consume ThinArc and returned the wrapped pointer.
     #[inline]
-    pub fn into_raw(self) -> *const c_void {
-        let this = ManuallyDrop::new(self);
-        this.ptr()
+    pub const fn into_raw(self) -> *const c_void {
+        let ret = self.ptr();
+        mem::forget(self);
+        ret
     }
 
     /// Provides a raw pointer to the data.
     /// The counts are not affected in any way and the ThinArc is not consumed.
     /// The pointer is valid for as long as there are strong counts in the ThinArc.
     #[inline]
-    pub fn as_ptr(&self) -> *const c_void {
+    pub const fn as_ptr(&self) -> *const c_void {
         self.ptr()
     }
 
@@ -314,14 +317,14 @@ impl<H, T> Arc<HeaderSliceWithLengthUnchecked<H, T>> {
     /// Converts a `ThinArc` into an `Arc`. This consumes the `ThinArc`, so the refcount
     /// is not modified.
     #[inline]
-    pub fn from_thin(a: ThinArc<H, T>) -> Self {
+    pub const fn from_thin(a: ThinArc<H, T>) -> Self {
         Self::from_protected(Arc::<HeaderSliceWithLengthProtected<H, T>>::protected_from_thin(a))
     }
 
     /// Converts an `Arc` into a `ThinArc`. This consumes the `Arc`, so the refcount
     /// is not modified.
     #[inline]
-    fn from_protected(a: Arc<HeaderSliceWithLengthProtected<H, T>>) -> Self {
+    const fn from_protected(a: Arc<HeaderSliceWithLengthProtected<H, T>>) -> Self {
         // Safety: HeaderSliceWithLengthProtected and HeaderSliceWithLengthUnchecked have the same layout
         // The whole `Arc` should also be layout compatible (as a transparent wrapper around `NonNull` pointers with the same
         // metadata type) but we still conservatively avoid a direct transmute here and use a pointer-cast instead.
@@ -352,9 +355,9 @@ impl<H, T> Arc<HeaderSliceWithLengthProtected<H, T>> {
     /// Converts a `ThinArc` into an `Arc`. This consumes the `ThinArc`, so the refcount
     /// is not modified.
     #[inline]
-    pub fn protected_from_thin(a: ThinArc<H, T>) -> Self {
-        let a = ManuallyDrop::new(a);
+    pub const fn protected_from_thin(a: ThinArc<H, T>) -> Self {
         let ptr = thin_to_thick(&a);
+        mem::forget(a);
         unsafe { Arc::from_raw_inner(ptr) }
     }
 
@@ -363,7 +366,9 @@ impl<H, T> Arc<HeaderSliceWithLengthProtected<H, T>> {
     /// # Safety
     /// Assumes that the header length matches the slice length.
     #[inline]
-    unsafe fn from_unprotected_unchecked(a: Arc<HeaderSliceWithLengthUnchecked<H, T>>) -> Self {
+    const unsafe fn from_unprotected_unchecked(
+        a: Arc<HeaderSliceWithLengthUnchecked<H, T>>,
+    ) -> Self {
         // Safety: HeaderSliceWithLengthProtected and HeaderSliceWithLengthUnchecked have the same layout
         // and the safety invariant on HeaderSliceWithLengthProtected.inner is bubbled up
         // The whole `Arc` should also be layout compatible (as a transparent wrapper around `NonNull` pointers with the same

--- a/src/thin_arc.rs
+++ b/src/thin_arc.rs
@@ -1,5 +1,6 @@
 use core::cmp::Ordering;
 use core::ffi::c_void;
+use core::fmt;
 use core::hash::{Hash, Hasher};
 use core::iter::{ExactSizeIterator, Iterator};
 use core::marker::PhantomData;
@@ -7,11 +8,10 @@ use core::mem::ManuallyDrop;
 use core::ops::Deref;
 use core::panic::{RefUnwindSafe, UnwindSafe};
 use core::ptr;
-use core::{fmt, mem};
 
 use super::{Arc, ArcInner, HeaderSlice, HeaderSliceWithLengthProtected, HeaderWithLength};
 use crate::header::HeaderSliceWithLengthUnchecked;
-use crate::AllocError;
+use crate::{mdref, AllocError};
 
 /// A "thin" `Arc` containing dynamically sized data
 ///
@@ -233,9 +233,8 @@ impl<H, T> ThinArc<H, T> {
     /// Consume ThinArc and returned the wrapped pointer.
     #[inline]
     pub const fn into_raw(self) -> *const c_void {
-        let ret = self.ptr();
-        mem::forget(self);
-        ret
+        let this = ManuallyDrop::new(self);
+        mdref(&this).ptr()
     }
 
     /// Provides a raw pointer to the data.
@@ -355,8 +354,8 @@ impl<H, T> Arc<HeaderSliceWithLengthProtected<H, T>> {
     /// is not modified.
     #[inline]
     pub const fn protected_from_thin(a: ThinArc<H, T>) -> Self {
-        let ptr = thin_to_thick(&a);
-        mem::forget(a);
+        let a = ManuallyDrop::new(a);
+        let ptr = thin_to_thick(mdref(&a));
         unsafe { Arc::from_raw_inner(ptr) }
     }
 

--- a/src/unique_arc.rs
+++ b/src/unique_arc.rs
@@ -3,7 +3,7 @@ use alloc::{alloc::Layout, boxed::Box};
 use core::convert::TryFrom;
 use core::iter::FromIterator;
 use core::marker::PhantomData;
-use core::mem::{ManuallyDrop, MaybeUninit};
+use core::mem::{self, ManuallyDrop, MaybeUninit};
 use core::ops::{Deref, DerefMut};
 use core::ptr::{self, addr_of_mut};
 
@@ -118,8 +118,13 @@ impl<T> UniqueArc<T> {
 impl<T: ?Sized> UniqueArc<T> {
     /// Convert to a shareable `Arc<T>` once we're done mutating it
     #[inline]
-    pub fn shareable(self) -> Arc<T> {
-        self.0
+    pub const fn shareable(self) -> Arc<T> {
+        let p = self.0.p;
+        mem::forget(self);
+        Arc {
+            p,
+            phantom: PhantomData,
+        }
     }
 
     /// Creates a new [`UniqueArc`] from the given [`Arc`].
@@ -167,7 +172,7 @@ impl<T> UniqueArc<MaybeUninit<T>> {
     }
 
     /// Obtain a mutable pointer to the stored `MaybeUninit<T>`.
-    pub fn as_mut_ptr(&mut self) -> *mut MaybeUninit<T> {
+    pub const fn as_mut_ptr(&mut self) -> *mut MaybeUninit<T> {
         unsafe { &mut (*self.0.ptr()).data }
     }
 
@@ -179,9 +184,11 @@ impl<T> UniqueArc<MaybeUninit<T>> {
     /// same safety requirements. You are responsible for ensuring that the `T`
     /// has actually been initialized before calling this method.
     #[inline]
-    pub unsafe fn assume_init(this: Self) -> UniqueArc<T> {
+    pub const unsafe fn assume_init(this: Self) -> UniqueArc<T> {
+        let p = this.0.p.cast();
+        mem::forget(this);
         UniqueArc(Arc {
-            p: ManuallyDrop::new(this).0.p.cast(),
+            p,
             phantom: PhantomData,
         })
     }
@@ -214,8 +221,10 @@ impl<T> UniqueArc<[MaybeUninit<T>]> {
     ///
     /// Must initialize all fields before calling this function.
     #[inline]
-    pub unsafe fn assume_init_slice(Self(this): Self) -> UniqueArc<[T]> {
-        UniqueArc(this.assume_init())
+    pub const unsafe fn assume_init_slice(this: Self) -> UniqueArc<[T]> {
+        let ptr = this.0.ptr();
+        mem::forget(this);
+        unsafe { UniqueArc(Arc::from_raw_inner(ptr as _)) }
     }
 }
 
@@ -270,7 +279,7 @@ impl<H, T> UniqueArc<HeaderSlice<H, [MaybeUninit<T>]>> {
     ///
     /// Must initialize all fields before calling this function.
     #[inline]
-    pub unsafe fn assume_init_slice_with_header(self) -> UniqueArc<HeaderSlice<H, [T]>> {
+    pub const unsafe fn assume_init_slice_with_header(self) -> UniqueArc<HeaderSlice<H, [T]>> {
         unsafe { core::mem::transmute(self) }
     }
 }

--- a/src/unique_arc.rs
+++ b/src/unique_arc.rs
@@ -11,7 +11,7 @@ use core::ptr::{self, addr_of_mut};
 use serde::{Deserialize, Serialize};
 
 use crate::iterator_as_exact_size_iterator::IteratorAsExactSizeIterator;
-use crate::{AllocError, HeaderSlice};
+use crate::{mdref, AllocError, HeaderSlice};
 
 use super::{Arc, ArcInner};
 
@@ -119,12 +119,9 @@ impl<T: ?Sized> UniqueArc<T> {
     /// Convert to a shareable `Arc<T>` once we're done mutating it
     #[inline]
     pub const fn shareable(self) -> Arc<T> {
-        let p = self.0.p;
-        mem::forget(self);
-        Arc {
-            p,
-            phantom: PhantomData,
-        }
+        let this = ManuallyDrop::new(self);
+        // Safety: UniqueArc isn't drop, just the inner Arc is
+        unsafe { mem::transmute_copy(&mdref(&this).0) }
     }
 
     /// Creates a new [`UniqueArc`] from the given [`Arc`].
@@ -185,10 +182,9 @@ impl<T> UniqueArc<MaybeUninit<T>> {
     /// has actually been initialized before calling this method.
     #[inline]
     pub const unsafe fn assume_init(this: Self) -> UniqueArc<T> {
-        let p = this.0.p.cast();
-        mem::forget(this);
+        let this = ManuallyDrop::new(this);
         UniqueArc(Arc {
-            p,
+            p: mdref(&this).0.p.cast(),
             phantom: PhantomData,
         })
     }
@@ -222,9 +218,7 @@ impl<T> UniqueArc<[MaybeUninit<T>]> {
     /// Must initialize all fields before calling this function.
     #[inline]
     pub const unsafe fn assume_init_slice(this: Self) -> UniqueArc<[T]> {
-        let ptr = this.0.ptr();
-        mem::forget(this);
-        unsafe { UniqueArc(Arc::from_raw_inner(ptr as _)) }
+        UniqueArc(this.shareable().assume_init())
     }
 }
 


### PR DESCRIPTION
Converts most `Arc`/`ThinArc`/`UniqueArc` methods to `const fn`. Only blocker was `ManuallyDrop`: wrapping a value in `ManuallyDrop::new(self)` and then reading a field back out isn't legal in a `const fn` (its `Deref`/`DerefMut` aren't const-callable). Replaced that pattern with "copy the raw pointer out first, then `mem::forget(self)`" — same effect, but const-friendly, though it does lose a tiny bit of unwind safety.

Also bumps MSRV from 1.81 to 1.85 to get some of the const methods.