### PR TITLE
Expand ArcBorrow for unsized types

### DIFF
--- a/src/arc_borrow.rs
+++ b/src/arc_borrow.rs
@@ -79,7 +79,7 @@ impl<'a, T> ArcBorrow<'a, T> {
     /// true if they come from the same allocation
     #[inline]
     pub fn ptr_eq(this: &Self, other: &Self) -> bool {
-        this.0 == other.0
+        core::ptr::addr_eq(this.0.as_ptr(), other.0.as_ptr())
     }
 
     /// The reference count of the underlying `Arc`.

--- a/src/arc_borrow.rs
+++ b/src/arc_borrow.rs
@@ -31,15 +31,15 @@ unsafe impl<'a, T: ?Sized + Sync + Send> Sync for ArcBorrow<'a, T> {}
 
 impl<'a, T: RefUnwindSafe + ?Sized> UnwindSafe for ArcBorrow<'a, T> {}
 
-impl<'a, T> Copy for ArcBorrow<'a, T> {}
-impl<'a, T> Clone for ArcBorrow<'a, T> {
+impl<'a, T: ?Sized> Copy for ArcBorrow<'a, T> {}
+impl<'a, T: ?Sized> Clone for ArcBorrow<'a, T> {
     #[inline]
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'a, T> ArcBorrow<'a, T> {
+impl<'a, T: ?Sized> ArcBorrow<'a, T> {
     /// Clone this as an `Arc<T>`. This bumps the refcount.
     #[inline]
     pub fn clone_arc(&self) -> Arc<T> {
@@ -61,9 +61,6 @@ impl<'a, T> ArcBorrow<'a, T> {
     /// For constructing from a pointer known to be Arc-backed,
     /// e.g. if we obtain such a pointer over FFI
     ///
-    // TODO: should from_ptr be relaxed to unsized types? It can't be
-    // converted back to an Arc right now for unsized types.
-    //
     /// # Safety
     /// - The pointer to `T` must have come from a Triomphe `Arc`, `UniqueArc`, or `ArcBorrow`.
     /// - The pointer to `T` must have full provenance over the `Arc`, `UniqueArc`, or `ArcBorrow`,
@@ -118,7 +115,7 @@ impl<'a, T> ArcBorrow<'a, T> {
     }
 }
 
-impl<'a, T> Deref for ArcBorrow<'a, T> {
+impl<'a, T: ?Sized> Deref for ArcBorrow<'a, T> {
     type Target = T;
 
     #[inline]
@@ -155,4 +152,14 @@ fn clone_arc_borrow() {
     let b: ArcBorrow<'_, i32> = x.borrow_arc();
     let y = b.clone_arc();
     assert_eq!(x, y);
+}
+
+#[test]
+fn clone_arc_borrow_str() {
+    let x: Arc<str> = Arc::from("hello");
+    let b: ArcBorrow<'_, str> = x.borrow_arc();
+    let y: Arc<str> = b.clone_arc();
+    assert_eq!(x, y);
+    assert_eq!(&*b, "hello");
+    assert!(ArcBorrow::ptr_eq(&b, &b));
 }

--- a/src/offset_arc.rs
+++ b/src/offset_arc.rs
@@ -175,3 +175,51 @@ impl<T: ?Sized> OffsetArc<T> {
         Self::with_arc(this, |arc| Arc::strong_count(arc))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn offset_arc_smoke() {
+        let arc = Arc::new(42);
+        let offset = Arc::into_raw_offset(arc);
+
+        assert_eq!(*offset, 42);
+        assert_eq!(OffsetArc::strong_count(&offset), 1);
+
+        let offset2 = offset.clone();
+        assert_eq!(OffsetArc::strong_count(&offset), 2);
+        assert_eq!(offset, offset2);
+
+        let regular_arc = offset2.clone_arc();
+        assert_eq!(Arc::strong_count(&regular_arc), 3);
+        drop(regular_arc);
+
+        drop(offset2);
+        assert_eq!(OffsetArc::strong_count(&offset), 1);
+
+        let mut offset = offset;
+        *offset.make_mut() = 99;
+        assert_eq!(*offset, 99);
+
+        let offset2 = offset.clone();
+        *offset.make_mut() = 100;
+        assert_eq!(*offset, 100);
+        assert_eq!(*offset2, 99);
+    }
+
+    #[test]
+    fn offset_arc_str() {
+        let s: OffsetArc<str> = OffsetArc::from("hello world");
+        assert_eq!(&*s, "hello world");
+        assert_eq!(OffsetArc::strong_count(&s), 1);
+
+        let b = s.borrow_arc();
+        assert_eq!(&*b, "hello world");
+
+        let s2 = s.clone();
+        assert_eq!(OffsetArc::strong_count(&s), 2);
+        assert_eq!(s, s2);
+    }
+}


### PR DESCRIPTION
We now have from_raw for unsized types.

Also uses `ptr::addr_eq` for better provenance.